### PR TITLE
feat: add shared image encoder module and tests

### DIFF
--- a/src/backend/image-service.ts
+++ b/src/backend/image-service.ts
@@ -13,12 +13,13 @@ import {
 } from './database'
 import { createUniqueId } from './id'
 import type { ImageRecord } from '../shared/models/image-record'
+import { EncodedImagePayload } from '../shared/models/encoded-image-payload'
 
 /**
  * Reads the image buffer from disk and returns it along with the DB token.
  * Throws if the image or database record is not found.
  */
-export const getImage = (id: string): { buffer: Buffer; token: number } => {
+export const getImage = (id: string): EncodedImagePayload => {
   const record = readImageRecord(id)
   if (!record) throw new Error(`Image record not found: ${id}`)
 

--- a/src/shared/image-encoder.ts
+++ b/src/shared/image-encoder.ts
@@ -1,0 +1,34 @@
+import { EncodedImagePayload } from './models/encoded-image-payload'
+
+/**
+ * Encodes an EncodedImagePayload into a binary Uint8Array.
+ * Layout: [token (8 bytes, LE)] [buffer]
+ */
+export function encodeImagePayload(payload: EncodedImagePayload): Uint8Array {
+  const { token, buffer } = payload
+
+  // Token as 8 bytes (Little Endian)
+  const tokenBuffer = new ArrayBuffer(8)
+  new DataView(tokenBuffer).setBigUint64(0, BigInt(token), true)
+
+  // Output: token (8 bytes) + buffer
+  const result = new Uint8Array(8 + buffer.length)
+  result.set(new Uint8Array(tokenBuffer), 0)
+  result.set(buffer, 8)
+
+  return result
+}
+
+/**
+ * Decodes a Uint8Array into an EncodedImagePayload.
+ */
+export function decodeImagePayload(data: Uint8Array): EncodedImagePayload {
+  const token = Number(
+    new DataView(data.buffer, data.byteOffset, data.byteLength).getBigUint64(
+      0,
+      true,
+    ),
+  )
+  const buffer = data.slice(8)
+  return { token, buffer }
+}

--- a/src/shared/models/encoded-image-payload.ts
+++ b/src/shared/models/encoded-image-payload.ts
@@ -1,0 +1,4 @@
+export interface EncodedImagePayload {
+  buffer: Buffer | Uint8Array
+  token: number
+}

--- a/tests/shared/image-encoder.test.ts
+++ b/tests/shared/image-encoder.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs'
+import path from 'path'
+import {
+  encodeImagePayload,
+  decodeImagePayload,
+} from '../../src/shared/image-encoder'
+import { EncodedImagePayload } from '../../src/shared/models/encoded-image-payload'
+
+describe('Image Encoder/Decoder – Round-Trip Integrity', () => {
+  const assetDir = path.resolve(__dirname, '..', 'assets')
+
+  const cases: { name: string; token: number; buffer: Uint8Array }[] = [
+    { name: 'empty buffer', token: 0, buffer: new Uint8Array([]) },
+    { name: 'small bytes', token: 7, buffer: new Uint8Array([1, 2, 3, 4, 5]) },
+    {
+      name: '1-pixel.png',
+      token: 42,
+      buffer: new Uint8Array(
+        fs.readFileSync(path.join(assetDir, '1-pixel.png')),
+      ),
+    },
+    {
+      name: '1-pixel.svg',
+      token: 43,
+      buffer: new Uint8Array(
+        fs.readFileSync(path.join(assetDir, '1-pixel.webp')),
+      ),
+    },
+    {
+      name: 'no-text.txt',
+      token: 44,
+      buffer: new Uint8Array(
+        fs.readFileSync(path.join(assetDir, 'no-text.txt')),
+      ),
+    },
+  ]
+
+  cases.forEach(({ name, token, buffer }) => {
+    it(`should correctly encode & decode for ${name}`, () => {
+      const payload: EncodedImagePayload = { token, buffer }
+      const encoded = encodeImagePayload(payload)
+      const decoded = decodeImagePayload(encoded)
+
+      expect(decoded.token).toBe(token)
+      expect(decoded.buffer).toEqual(buffer)
+    })
+  })
+})
+
+describe('Image Encoder/Decoder – Edge Cases', () => {
+  it('throws if input length is less than 8 bytes', () => {
+    expect(() => decodeImagePayload(new Uint8Array(7))).toThrow(RangeError)
+  })
+
+  it('preserves little-endian token format', () => {
+    const token = 0x0102030405060708
+    const buffer = new Uint8Array([255, 128, 0])
+    const encoded = encodeImagePayload({ token, buffer })
+
+    // Manually read the first 8 bytes as little-endian
+    const dv = new DataView(
+      encoded.buffer,
+      encoded.byteOffset,
+      encoded.byteLength,
+    )
+    const readToken = Number(dv.getBigUint64(0, true))
+
+    expect(readToken).toBe(token)
+    expect(new Uint8Array(encoded.slice(8))).toEqual(buffer)
+  })
+})


### PR DESCRIPTION
- Adds encodeImagePayload and decodeImagePayload functions to shared/image-encoder.ts
- Defines EncodedImagePayload type (token + buffer) in shared/encoded-image-payload.ts
- Includes comprehensive tests:
  - Empty buffer, small byte array
  - Real binary files: 1-pixel.png, 1-pixel.webp, no-text.txt
  - Endianness validation and error on <8 byte input

Closes #8