### PR TITLE
feat: implement low-level image record CRUD in frontend using IndexedDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^24.0.1",
         "eslint": "^9.29.0",
+        "fake-indexeddb": "^6.0.1",
         "globals": "^16.2.0",
         "jest": "^29.7.0",
         "prettier": "^3.5.3",
@@ -2831,6 +2832,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+      "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^24.0.1",
     "eslint": "^9.29.0",
+    "fake-indexeddb": "^6.0.1",
     "globals": "^16.2.0",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",

--- a/src/frontend/database.ts
+++ b/src/frontend/database.ts
@@ -4,8 +4,9 @@ import {
   IMAGE_STORE_NAME,
   TEMP_IMAGE_STORE_NAME,
 } from '../constants'
+import { FrontendImageRecord } from '../shared/models/frontend-image-record'
 
-let db: IDBDatabase | null = null
+let database: IDBDatabase | null = null
 
 /**
  * Opens the frontend IndexedDB instance and ensures required object stores exist.
@@ -14,25 +15,105 @@ let db: IDBDatabase | null = null
  * Returns a promise that resolves to the IDBDatabase connection.
  */
 export function openDatabase(): Promise<IDBDatabase> {
-  if (db) return Promise.resolve(db)
+  if (database) return Promise.resolve(database)
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(FRONTEND_DB_NAME, FRONTEND_DB_VERSION)
 
     request.onupgradeneeded = (event) => {
-      const db = request.result
+      const database = request.result
       // Ensure the main image store exists
-      if (!db.objectStoreNames.contains(IMAGE_STORE_NAME)) {
-        db.createObjectStore(IMAGE_STORE_NAME, { keyPath: 'id' })
+      if (!database.objectStoreNames.contains(IMAGE_STORE_NAME)) {
+        database.createObjectStore(IMAGE_STORE_NAME, { keyPath: 'id' })
       }
       // Ensure the temp store exists (used for migration/cleanup)
-      if (!db.objectStoreNames.contains(TEMP_IMAGE_STORE_NAME)) {
-        db.createObjectStore(TEMP_IMAGE_STORE_NAME, { keyPath: 'id' })
+      if (!database.objectStoreNames.contains(TEMP_IMAGE_STORE_NAME)) {
+        database.createObjectStore(TEMP_IMAGE_STORE_NAME, { keyPath: 'id' })
       }
     }
     request.onsuccess = () => {
-      db = request.result
-      resolve(db)
+      database = request.result
+      resolve(database)
     }
+    request.onerror = () => reject(request.error)
+  })
+}
+
+/**
+ * Reads an image record from IndexedDB by its id.
+ * Returns the FrontendImageRecord if found, otherwise null.
+ */
+export const readImageRecord = async (
+  id: string,
+): Promise<FrontendImageRecord | null> => {
+  // Wait for the IndexedDB connection to be available
+  const database = await openDatabase()
+  // Start a readonly transaction on the main image store
+  const transaction = database.transaction(IMAGE_STORE_NAME, 'readonly')
+  const store = transaction.objectStore(IMAGE_STORE_NAME)
+  // Attempt to get the record by id
+  return await new Promise<FrontendImageRecord | null>((resolve, reject) => {
+    const request = store.get(id)
+    request.onsuccess = () => {
+      // If record exists, resolve with the object; else resolve with null
+      resolve(request.result ?? null)
+    }
+    request.onerror = () => reject(request.error)
+  })
+}
+
+/**
+ * Saves an image record to IndexedDB.
+ * If a record with the same id exists, it will be overwritten.
+ * Uses 'put' operation (insert or update).
+ */
+export const writeImageRecord = async (
+  record: FrontendImageRecord,
+): Promise<void> => {
+  // Wait for the IndexedDB connection to be available
+  const database = await openDatabase()
+  // Start a readwrite transaction on the main image store
+  const transaction = database.transaction(IMAGE_STORE_NAME, 'readwrite')
+  const store = transaction.objectStore(IMAGE_STORE_NAME)
+  // Put the record (insert or update)
+  await new Promise<void>((resolve, reject) => {
+    const request = store.put(record)
+    request.onsuccess = () => resolve()
+    request.onerror = () => reject(request.error)
+  })
+}
+
+/**
+ * Deletes an image record from IndexedDB by its id.
+ * If the record does not exist, does nothing (no error).
+ */
+export const deleteImageRecord = async (id: string): Promise<void> => {
+  // Wait for the IndexedDB connection to be available
+  const database = await openDatabase()
+  // Start a readwrite transaction on the main image store
+  const transaction = database.transaction(IMAGE_STORE_NAME, 'readwrite')
+  const store = transaction.objectStore(IMAGE_STORE_NAME)
+  // Delete the record by id
+  await new Promise<void>((resolve, reject) => {
+    const request = store.delete(id)
+    request.onsuccess = () => resolve()
+    request.onerror = () => reject(request.error)
+  })
+}
+
+/**
+ * Checks if an image record exists in IndexedDB by its id.
+ * Resolves to true if the record exists, otherwise false.
+ */
+export const imageRecordExists = async (id: string): Promise<boolean> => {
+  // Wait for the IndexedDB connection to be available
+  const database = await openDatabase()
+  // Start a readonly transaction on the main image store
+  const transaction = database.transaction(IMAGE_STORE_NAME, 'readonly')
+  const store = transaction.objectStore(IMAGE_STORE_NAME)
+  // Get the record by id and check if result is not undefined
+  return await new Promise<boolean>((resolve, reject) => {
+    const request = store.get(id)
+    request.onsuccess = () => resolve(request.result !== undefined)
     request.onerror = () => reject(request.error)
   })
 }

--- a/src/shared/models/frontend-image-record.ts
+++ b/src/shared/models/frontend-image-record.ts
@@ -1,5 +1,6 @@
 export type FrontendImageRecord = {
   id: string
+  data: Blob
   token: number
   lastUsed: number
 }

--- a/tests/modules/frontend/database.test.ts
+++ b/tests/modules/frontend/database.test.ts
@@ -1,0 +1,64 @@
+import 'fake-indexeddb/auto'
+import {
+  writeImageRecord,
+  readImageRecord,
+  deleteImageRecord,
+  imageRecordExists,
+} from '../../../src/frontend/database'
+import { FrontendImageRecord } from '../../../src/shared/models/frontend-image-record'
+
+describe('Frontend Database CRUD', () => {
+  const id = 'city:1232323'
+  const initialBlob = new Blob(['mockdata-1'], { type: 'image/jpeg' })
+  const updatedBlob = new Blob(['mockdata-2'], { type: 'image/jpeg' })
+
+  const record: FrontendImageRecord = {
+    id,
+    data: initialBlob,
+    token: 42,
+    lastUsed: Date.now(),
+  }
+
+  it('writes and reads an image record', async () => {
+    await writeImageRecord(record)
+    const result = await readImageRecord(id)
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe(id)
+    expect(result?.token).toBe(42)
+    expect(result?.data).toBeInstanceOf(Blob)
+    expect(result?.data.type).toBe('image/jpeg')
+    // Check the blob content matches the original
+    const text = await result!.data.text()
+    expect(text).toBe('mockdata-1')
+  })
+
+  it('updates an image record and verifies blob/content change', async () => {
+    const updated: FrontendImageRecord = {
+      id,
+      data: updatedBlob,
+      token: 99,
+      lastUsed: Date.now(),
+    }
+    await writeImageRecord(updated)
+    const res = await readImageRecord(id)
+    expect(res).not.toBeNull()
+    expect(res?.token).toBe(99)
+    expect(res?.data).toBeInstanceOf(Blob)
+    expect(res?.data.type).toBe('image/jpeg')
+    // Ensure the blob content is updated
+    const text = await res!.data.text()
+    expect(text).toBe('mockdata-2')
+  })
+
+  it('checks for record existence', async () => {
+    expect(await imageRecordExists(id)).toBe(true)
+    expect(await imageRecordExists('nonexistent')).toBe(false)
+  })
+
+  it('deletes an image record and confirms deletion', async () => {
+    await deleteImageRecord(id)
+    const res = await readImageRecord(id)
+    expect(res).toBeNull()
+    expect(await imageRecordExists(id)).toBe(false)
+  })
+})


### PR DESCRIPTION
- Add write, read, delete, and existence check operations for image storage in the frontend database
- Integrate low-level CRUD methods with new FrontendImageRecord type
- Provide async, promise-based API compatible with browser IndexedDB
- Ensure coverage with tests using fake-indexeddb and Jest

Closes #14