### PR TITLE
feat: add default fetcher module for default endpoint image retrieval

### DIFF
--- a/src/backend/image-service.ts
+++ b/src/backend/image-service.ts
@@ -13,14 +13,14 @@ import {
 } from './database'
 import { createUniqueId } from './id'
 import type { BackendImageRecord } from '../shared/models/backend-image-record'
-import { EncodedImagePayload } from '../shared/models/encoded-image-payload'
-import { getImageFormat, imageFormatToByte } from './image-format'
+import { ImagePayload } from '../shared/models/image-payload'
+import { getImageFormat } from './image-format'
 
 /**
  * Reads the image buffer from disk and returns it along with the DB token.
  * Throws if the image or database record is not found.
  */
-export const getImage = async (id: string): Promise<EncodedImagePayload> => {
+export const getImage = async (id: string): Promise<ImagePayload> => {
   const record = readImageRecord(id)
   if (!record) throw new Error(`Image record not found: ${id}`)
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,8 @@ export const IMAGE_ROOT_DIR = IS_TEST
 
 export const DEFAULT_ENDPOINT_HOST = IS_TEST ? '127.0.0.1' : '0.0.0.0'
 
+export const SERVER_HOST = IS_TEST ? '127.0.0.1' : 'unknown'
+
 export const DEFAULT_ENDPOINT_PORT = 3001
 
 export const DEFAULT_ENDPOINT_ROUTE = '/pixstore-image'

--- a/src/frontend/default-fetcher.ts
+++ b/src/frontend/default-fetcher.ts
@@ -1,0 +1,35 @@
+import {
+  DEFAULT_ENDPOINT_PORT,
+  DEFAULT_ENDPOINT_ROUTE,
+  SERVER_HOST,
+} from '../constants'
+
+/**
+ * Fetches a raw encoded image payload from the Pixstore backend.
+ *
+ * This performs a direct HTTP GET request to the default image endpoint using
+ * the wire format protocol: [1 byte format][8 byte token][N bytes buffer].
+ */
+export const fetchEncodedImage = async (id: string): Promise<Uint8Array> => {
+  // Construct the full URL using constants
+  const url = `http://${SERVER_HOST}:${DEFAULT_ENDPOINT_PORT}${DEFAULT_ENDPOINT_ROUTE}/${encodeURIComponent(id)}`
+
+  // Perform the HTTP request
+  const res = await fetch(url)
+
+  // Ensure the response is OK (200-level)
+  if (!res.ok) {
+    throw new Error(`Failed to fetch image: ${res.status} ${res.statusText}`)
+  }
+
+  // Read and convert response body to Uint8Array
+  const buffer = await res.arrayBuffer()
+  const uint8 = new Uint8Array(buffer)
+
+  // Sanity check: payload must include format(1) + token(8)
+  if (uint8.length < 9) {
+    throw new Error('Invalid payload: too short')
+  }
+
+  return uint8
+}

--- a/src/shared/image-encoder.ts
+++ b/src/shared/image-encoder.ts
@@ -1,14 +1,11 @@
 import { byteToImageFormat, imageFormatToByte } from '../backend/image-format'
-
-import { EncodedImagePayload } from './models/encoded-image-payload'
+import { ImagePayload } from './models/image-payload'
 
 /**
- * Encodes an EncodedImagePayload into a binary Uint8Array.
+ * Encodes an ImagePayload into a binary Uint8Array.
  * Layout: [format (1 byte)] [token (8 bytes, LE)] [buffer]
  */
-export const encodeImagePayload = (
-  payload: EncodedImagePayload,
-): Uint8Array => {
+export const encodeImagePayload = (payload: ImagePayload): Uint8Array => {
   const { imageFormat, token, buffer } = payload
 
   // Encode image format as 1 byte
@@ -27,10 +24,10 @@ export const encodeImagePayload = (
 }
 
 /**
- * Decodes a Uint8Array into an EncodedImagePayload.
+ * Decodes a Uint8Array into an ImagePayload.
  * Expects: [format (1 byte)] [token (8 bytes, LE)] [buffer]
  */
-export const decodeImagePayload = (data: Uint8Array): EncodedImagePayload => {
+export const decodeImagePayload = (data: Uint8Array): ImagePayload => {
   const formatByte = data[0]
   const imageFormat = byteToImageFormat(formatByte)
   const token = Number(

--- a/src/shared/models/image-payload.ts
+++ b/src/shared/models/image-payload.ts
@@ -1,6 +1,6 @@
 import { ImageFormat } from './image-format'
 
-export interface EncodedImagePayload {
+export interface ImagePayload {
   buffer: Uint8Array
   token: number
   imageFormat: ImageFormat

--- a/tests/modules/frontend/default-fetcher.test.ts
+++ b/tests/modules/frontend/default-fetcher.test.ts
@@ -1,0 +1,45 @@
+import {
+  startDefaultEndpoint,
+  stopDefaultEndpoint,
+} from '../../../src/backend/default-endpoint'
+import { saveImageFromFile } from '../../../src/backend/image-service'
+import { fetchEncodedImage } from '../../../src/frontend/default-fetcher'
+import { decodeImagePayload } from '../../../src/shared/image-encoder'
+import fs from 'fs/promises'
+import path from 'path'
+import { BackendImageRecord } from '../../../src/shared/models/backend-image-record'
+
+const assetsDir = path.resolve(__dirname, '../../assets')
+const TEST_IMAGE_PATH = path.join(assetsDir, 'antalya.jpg')
+
+describe('fetchEncodedImage (integration)', () => {
+  let record: BackendImageRecord
+  beforeAll(async () => {
+    startDefaultEndpoint()
+    record = await saveImageFromFile(TEST_IMAGE_PATH)
+  })
+
+  afterAll(async () => {
+    await stopDefaultEndpoint()
+  })
+
+  it('fetches and decodes the image as expected', async () => {
+    const encoded = await fetchEncodedImage(record.id)
+    const payload = decodeImagePayload(encoded)
+
+    expect(payload.imageFormat).toBe('jpg')
+    expect(payload.buffer).toBeInstanceOf(Uint8Array)
+    expect(payload.buffer.length).toBeGreaterThan(0)
+
+    const original = await fs.readFile(TEST_IMAGE_PATH)
+    expect(payload.buffer.length).toBe(original.length)
+
+    expect(payload.token).toBe(record.token)
+  })
+
+  it('throws if the image does not exist', async () => {
+    await expect(fetchEncodedImage('fetcher:notfound')).rejects.toThrow(
+      'Failed to fetch image',
+    )
+  })
+})

--- a/tests/modules/shared/image-encoder.test.ts
+++ b/tests/modules/shared/image-encoder.test.ts
@@ -4,7 +4,7 @@ import {
   encodeImagePayload,
   decodeImagePayload,
 } from '../../../src/shared/image-encoder'
-import { EncodedImagePayload } from '../../../src/shared/models/encoded-image-payload'
+import { ImagePayload } from '../../../src/shared/models/image-payload'
 import { ImageFormat } from '../../../src/shared/models/image-format'
 import { IMAGE_FORMATS } from '../../../src/constants'
 
@@ -58,7 +58,7 @@ describe('Image Encoder/Decoder – Round-Trip Integrity', () => {
 
   cases.forEach(({ name, imageFormat, token, buffer }) => {
     it(`should correctly encode & decode for ${name}`, () => {
-      const payload: EncodedImagePayload = { imageFormat, token, buffer }
+      const payload: ImagePayload = { imageFormat, token, buffer }
       const encoded = encodeImagePayload(payload)
       const decoded = decodeImagePayload(encoded)
 


### PR DESCRIPTION
- Implements low-level image fetcher for the Pixstore default endpoint
- Uses SERVER_HOST, DEFAULT_ENDPOINT_PORT, and DEFAULT_ENDPOINT_ROUTE constants
- Includes integration test with real backend and sample image

Closes #21