### PR TITLE
feat: add frontend image formatter and refactor format handling

### DIFF
--- a/src/backend/default-endpoint.ts
+++ b/src/backend/default-endpoint.ts
@@ -73,12 +73,12 @@ const requestHandler = (
  * - Suppresses console output in test mode.
  * - Uses `unref()` so Jest or other processes can exit cleanly.
  */
-export const startDefaultEndpoint = (): void => {
+export const startDefaultEndpoint = (port = DEFAULT_ENDPOINT_PORT): void => {
   if (server) return
 
   server = http
     .createServer(requestHandler)
-    .listen(DEFAULT_ENDPOINT_PORT, DEFAULT_ENDPOINT_HOST, () => {
+    .listen(port, DEFAULT_ENDPOINT_HOST, () => {
       if (!IS_TEST) {
         console.log(
           `Pixstore endpoint listening on ${DEFAULT_ENDPOINT_HOST}:${DEFAULT_ENDPOINT_PORT}`,

--- a/src/backend/file-storage.ts
+++ b/src/backend/file-storage.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises'
 import path from 'path'
 import { toFilePath } from './id'
-import { isValidImage } from './image-format'
+import { isValidImage } from './format-image'
 
 /**
  * Saves the image buffer to disk at the canonical file path for the given id.

--- a/src/backend/format-image.ts
+++ b/src/backend/format-image.ts
@@ -6,19 +6,16 @@ import {
 import imageType from 'image-type'
 import { ImageFormat } from '../shared/models/image-format'
 
-// Build mapping tables once on module load.
-IMAGE_FORMATS.forEach((imageFormat: ImageFormat, imageID: number) => {
-  // 0 is reserved for unknown/invalid, so use (imageID + 1)
-  IMAGE_FORMAT_TO_BYTE.set(imageFormat, imageID + 1)
-  BYTE_TO_IMAGE_FORMAT.set(imageID + 1, imageFormat)
-})
-
 /**
  * Converts an ImageFormat string (e.g., 'jpeg', 'png') to its protocol byte value.
  * Returns 0 for unknown/unsupported formats.
  */
 export const imageFormatToByte = (format: ImageFormat): number => {
-  return IMAGE_FORMAT_TO_BYTE.get(format) ?? 0
+  const byte = IMAGE_FORMAT_TO_BYTE.get(format)
+  if (byte === undefined) {
+    throw new Error(`Unsupported image format: ${format}`)
+  }
+  return byte
 }
 
 /**
@@ -26,9 +23,12 @@ export const imageFormatToByte = (format: ImageFormat): number => {
  * Returns the first entry of IMAGE_FORMATS as fallback if the byte is invalid.
  */
 export const byteToImageFormat = (byte: number): ImageFormat => {
-  return BYTE_TO_IMAGE_FORMAT.get(byte) ?? IMAGE_FORMATS[0]
+  const format = BYTE_TO_IMAGE_FORMAT.get(byte)
+  if (format === undefined) {
+    throw new Error(`Unknown image format byte: ${byte}`)
+  }
+  return format
 }
-
 /**
  * Checks if the given buffer is a valid image of supported type.
  */

--- a/src/backend/image-service.ts
+++ b/src/backend/image-service.ts
@@ -14,7 +14,7 @@ import {
 import { createUniqueId } from './id'
 import type { BackendImageRecord } from '../shared/models/backend-image-record'
 import { ImagePayload } from '../shared/models/image-payload'
-import { getImageFormat } from './image-format'
+import { getImageFormat } from './format-image'
 
 /**
  * Reads the image buffer from disk and returns it along with the DB token.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,13 @@ export const IMAGE_FORMAT_TO_BYTE = new Map<ImageFormat, number>()
 
 export const BYTE_TO_IMAGE_FORMAT = new Map<number, ImageFormat>()
 
+// Build mapping tables once on module load.
+IMAGE_FORMATS.forEach((imageFormat: ImageFormat, imageID: number) => {
+  // 0 is reserved for unknown/invalid, so use (imageID + 1)
+  IMAGE_FORMAT_TO_BYTE.set(imageFormat, imageID + 1)
+  BYTE_TO_IMAGE_FORMAT.set(imageID + 1, imageFormat)
+})
+
 export const IMAGE_EXTENSION = '.pixstore-image'
 
 export const IMAGE_ROOT_DIR = IS_TEST
@@ -23,7 +30,9 @@ export const DEFAULT_ENDPOINT_HOST = IS_TEST ? '127.0.0.1' : '0.0.0.0'
 
 export const SERVER_HOST = IS_TEST ? '127.0.0.1' : 'unknown'
 
-export const DEFAULT_ENDPOINT_PORT = 3001
+export const DEFAULT_ENDPOINT_PORT = IS_TEST
+  ? 10000 + Math.floor(Math.random() * 50000)
+  : 3001
 
 export const DEFAULT_ENDPOINT_ROUTE = '/pixstore-image'
 

--- a/src/frontend/format-image.ts
+++ b/src/frontend/format-image.ts
@@ -1,0 +1,33 @@
+import { IMAGE_FORMATS } from '../constants'
+import { decodeImagePayload } from '../shared/image-encoder'
+import { FrontendImageRecord } from '../shared/models/frontend-image-record'
+import { ImageFormat } from '../shared/models/image-format'
+
+/**
+ * Converts an image format (e.g. 'png') to the corresponding MIME type.
+ * Throws if the format is not supported.
+ */
+function imageFormatToMime(format: ImageFormat): string {
+  if (!IMAGE_FORMATS.includes(format))
+    throw new Error(`Unsupported image format: ${format}`)
+  return `image/${format}`
+}
+
+/**
+ * Converts a wire-encoded image payload to a FrontendImageRecord.
+ * Decodes payload, determines MIME type, and creates a Blob for browser use.
+ */
+export const formatEncodedImage = (
+  id: string,
+  encoded: Uint8Array,
+): FrontendImageRecord => {
+  const { buffer, token, imageFormat } = decodeImagePayload(encoded)
+  const mime = imageFormatToMime(imageFormat)
+  const data = new Blob([new Uint8Array(buffer)], { type: mime })
+  return {
+    id,
+    data,
+    token,
+    lastUsed: Date.now(),
+  }
+}

--- a/src/shared/image-encoder.ts
+++ b/src/shared/image-encoder.ts
@@ -1,4 +1,4 @@
-import { byteToImageFormat, imageFormatToByte } from '../backend/image-format'
+import { byteToImageFormat, imageFormatToByte } from '../backend/format-image'
 import { ImagePayload } from './models/image-payload'
 
 /**

--- a/tests/modules/backend/default-endpoint.test.ts
+++ b/tests/modules/backend/default-endpoint.test.ts
@@ -7,8 +7,8 @@ import {
 } from '../../../src/backend/image-service'
 import {
   DEFAULT_ENDPOINT_HOST,
-  DEFAULT_ENDPOINT_PORT,
   DEFAULT_ENDPOINT_ROUTE,
+  DEFAULT_ENDPOINT_PORT,
 } from '../../../src/constants'
 import { decodeImagePayload } from '../../../src/shared/image-encoder'
 import {
@@ -17,7 +17,7 @@ import {
 } from '../../../src/backend/default-endpoint'
 
 beforeAll(() => startDefaultEndpoint())
-afterAll(() => stopDefaultEndpoint())
+afterAll(async () => await stopDefaultEndpoint())
 
 const BASE_URL = `http://${DEFAULT_ENDPOINT_HOST}:${DEFAULT_ENDPOINT_PORT}`
 const assetDir = path.resolve(__dirname, '../..', 'assets')

--- a/tests/modules/backend/format-image.test.ts
+++ b/tests/modules/backend/format-image.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { IMAGE_FORMATS } from '../../../src/constants'
-import { isValidImage } from '../../../src/backend/image-format'
+import { isValidImage } from '../../../src/backend/format-image'
 
 const assetsDir = path.resolve(__dirname, '../../assets')
 const pngBuffer = fs.readFileSync(path.join(assetsDir, '1-pixel.png'))

--- a/tests/modules/frontend/default-fetcher.test.ts
+++ b/tests/modules/frontend/default-fetcher.test.ts
@@ -15,10 +15,9 @@ const TEST_IMAGE_PATH = path.join(assetsDir, 'antalya.jpg')
 describe('fetchEncodedImage (integration)', () => {
   let record: BackendImageRecord
   beforeAll(async () => {
-    startDefaultEndpoint()
     record = await saveImageFromFile(TEST_IMAGE_PATH)
   })
-
+  startDefaultEndpoint()
   afterAll(async () => {
     await stopDefaultEndpoint()
   })

--- a/tests/modules/frontend/format-image.test.ts
+++ b/tests/modules/frontend/format-image.test.ts
@@ -1,0 +1,29 @@
+import { formatEncodedImage } from '../../../src/frontend/format-image'
+import { encodeImagePayload } from '../../../src/shared/image-encoder'
+
+describe('formatEncodedImage', () => {
+  it('decodes valid encoded payload and returns a FrontendImageRecord', () => {
+    // Dummy data: png, token=42, buffer=[1,2,3]
+    const payload = encodeImagePayload({
+      imageFormat: 'png',
+      token: 42,
+      buffer: new Uint8Array([1, 2, 3]),
+    })
+    const id = 'test-id'
+    const record = formatEncodedImage(id, payload)
+
+    expect(record.id).toBe(id)
+    expect(record.token).toBe(42)
+    expect(record.data).toBeInstanceOf(Blob)
+    expect(record.data.type).toBe('image/png')
+    expect(record.lastUsed).toBeGreaterThan(0)
+  })
+
+  it('throws for unsupported image format', () => {
+    const fakePayload = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+
+    expect(() => formatEncodedImage('bad-id', fakePayload)).toThrow(
+      'Unknown image format byte: 0',
+    )
+  })
+})

--- a/tests/modules/shared/image-encoder.test.ts
+++ b/tests/modules/shared/image-encoder.test.ts
@@ -71,7 +71,7 @@ describe('Image Encoder/Decoder – Round-Trip Integrity', () => {
 
 describe('Image Encoder/Decoder – Edge Cases', () => {
   it('throws if input length is less than 9 bytes', () => {
-    expect(() => decodeImagePayload(new Uint8Array(8))).toThrow(RangeError)
+    expect(() => decodeImagePayload(new Uint8Array(8))).toThrow(Error)
   })
 
   it('preserves little-endian token format and leaves buffer intact', () => {


### PR DESCRIPTION
- Implements formatEncodedImage to convert wire payload into FrontendImageRecord
- Adds MIME mapping and Blob generation for frontend rendering
- Replaces backend/image-format.ts with format-image.ts for naming consistency
- Updates encoder to throw on unknown formats, ensuring stricter correctness
- Adds integration and unit tests for image formatter, encoder, and format edge cases

Closes #23