### PR TITLE
feat: add customEndpointHelper for custom backend endpoint integration

### DIFF
--- a/src/backend/custom-endpoint.ts
+++ b/src/backend/custom-endpoint.ts
@@ -1,0 +1,18 @@
+import { getImage } from './image-service'
+import { encodeImagePayload } from '../shared/image-encoder'
+import { isServerStarted } from './default-endpoint'
+
+/**
+ * Returns a Pixstore wire format encoded image payload (Uint8Array) for the given image id.
+ * Throws if the default endpoint is running, to prevent accidental double endpoint use.
+ * Can be used in any custom endpoint handler to build a response.
+ */
+export const customEndpointHelper = async (id: string): Promise<Uint8Array> => {
+  if (isServerStarted()) {
+    throw new Error(
+      'Pixstore custom endpoint mode is not active. Please disable the default endpoint before using customEndpointHelper().',
+    )
+  }
+  const image = await getImage(id)
+  return encodeImagePayload(image)
+}

--- a/src/backend/default-endpoint.ts
+++ b/src/backend/default-endpoint.ts
@@ -101,3 +101,9 @@ export const stopDefaultEndpoint = (): Promise<void> => {
     server.close((err) => (err ? reject(err) : resolve()))
   })
 }
+
+/**
+ * Returns true if the default endpoint server is currently started.
+ * Useful to prevent accidental double-start or for debugging/status checks.
+ */
+export const isServerStarted = (): boolean => !!server

--- a/tests/modules/backend/custom-endpoint.test.ts
+++ b/tests/modules/backend/custom-endpoint.test.ts
@@ -1,0 +1,38 @@
+import { customEndpointHelper } from '../../../src/backend/custom-endpoint'
+import {
+  startDefaultEndpoint,
+  stopDefaultEndpoint,
+} from '../../../src/backend/default-endpoint'
+import { saveImage } from '../../../src/backend/image-service'
+import fs from 'fs/promises'
+import path from 'path'
+import { sleep } from '../../utils'
+
+const assetDir = path.resolve(__dirname, '../../assets')
+const ANTALYA_PATH = path.join(assetDir, 'antalya.jpg')
+
+describe('customEndpointHelper', () => {
+  let id: string
+
+  beforeAll(async () => {
+    // Save a test image to backend and keep the ID
+    const saved = await saveImage(await fs.readFile(ANTALYA_PATH), 'students')
+    id = saved.id
+  })
+
+  it('returns valid wire format payload when default endpoint is not running', async () => {
+    const payload = await customEndpointHelper(id)
+    // Payload must be a Uint8Array and at least 9 bytes (wire format minimum)
+    expect(payload).toBeInstanceOf(Uint8Array)
+    expect(payload.length).toBeGreaterThan(8)
+  })
+
+  it('throws if default endpoint is running', async () => {
+    startDefaultEndpoint()
+    await sleep(50)
+    await expect(customEndpointHelper(id)).rejects.toThrow(
+      /custom endpoint mode is not active|default endpoint/i,
+    )
+    await stopDefaultEndpoint()
+  })
+})

--- a/tests/modules/backend/database.test.ts
+++ b/tests/modules/backend/database.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../src/backend/database'
 
 import fs from 'fs'
+import { sleep } from '../../utils'
 
 const dbPath =
   process.env.NODE_ENV === 'test'
@@ -43,7 +44,7 @@ describe('writeImageRecord - update behavior', () => {
 
   it('overwrites record and generates new token', async () => {
     const initialWrite = writeImageRecord(testId)
-    await new Promise((res) => setTimeout(res, 10)) // ensure timestamp gap
+    await sleep(10) // ensure timestamp gap
     const overwrittenWrite = writeImageRecord(testId)
 
     expect(overwrittenWrite.token).toBeGreaterThan(initialWrite.token)

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Simple async sleep for tests.
+ * Usage: await sleep(10)
+ */
+export const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms))


### PR DESCRIPTION
- Adds customEndpointHelper(id) for producing Pixstore wire format in any custom backend handler
- Prevents usage if default endpoint is running
- Includes integration tests covering both normal usage and endpoint conflict
- Adds sleep utility for reliable async tests

Closes #11