### PR TITLE
feat: add modular image fetcher system with custom and default support

### DIFF
--- a/src/frontend/custom-image-fetcher.ts
+++ b/src/frontend/custom-image-fetcher.ts
@@ -1,0 +1,19 @@
+/**
+ * Stores the current custom fetcher function if registered by the user.
+ */
+let customImageFetcher: ((id: string) => Promise<Uint8Array>) | undefined
+
+/**
+ * Registers a custom fetcher function for image retrieval.
+ * When set, this function will be used instead of the default fetcher.
+ */
+export const registerCustomImageFetcher = (
+  fetcher: (id: string) => Promise<Uint8Array>,
+) => {
+  customImageFetcher = fetcher
+}
+
+/**
+ * Returns the registered custom fetcher function, if any.
+ */
+export const getCustomImageFetcher = () => customImageFetcher

--- a/src/frontend/default-image-fetcher.ts
+++ b/src/frontend/default-image-fetcher.ts
@@ -10,7 +10,7 @@ import {
  * This performs a direct HTTP GET request to the default image endpoint using
  * the wire format protocol: [1 byte format][8 byte token][N bytes buffer].
  */
-export const fetchEncodedImage = async (id: string): Promise<Uint8Array> => {
+const defaultImageFetcher = async (id: string): Promise<Uint8Array> => {
   // Construct the full URL using constants
   const url = `http://${SERVER_HOST}:${DEFAULT_ENDPOINT_PORT}${DEFAULT_ENDPOINT_ROUTE}/${encodeURIComponent(id)}`
 
@@ -26,10 +26,7 @@ export const fetchEncodedImage = async (id: string): Promise<Uint8Array> => {
   const buffer = await res.arrayBuffer()
   const uint8 = new Uint8Array(buffer)
 
-  // Sanity check: payload must include format(1) + token(8)
-  if (uint8.length < 9) {
-    throw new Error('Invalid payload: too short')
-  }
-
   return uint8
 }
+
+export const getDefaultImageFetcher = () => defaultImageFetcher

--- a/src/frontend/image-fetcher.ts
+++ b/src/frontend/image-fetcher.ts
@@ -1,0 +1,17 @@
+import { getCustomImageFetcher } from './custom-image-fetcher'
+import { getDefaultImageFetcher } from './default-image-fetcher'
+
+/**
+ * Fetches a raw encoded image payload using either a custom fetcher
+ * (if registered) or the default Pixstore fetcher.
+ * Always returns the wire-format Uint8Array for the given image id.
+ */
+export const fetchEncodedImage = async (id: string): Promise<Uint8Array> => {
+  const customImageFetcher = getCustomImageFetcher()
+
+  const imageFetcher = customImageFetcher
+    ? customImageFetcher
+    : getDefaultImageFetcher()
+
+  return imageFetcher(id)
+}

--- a/src/frontend/image-service.ts
+++ b/src/frontend/image-service.ts
@@ -3,7 +3,7 @@ import {
   writeImageRecord,
   deleteImageRecord,
 } from './database'
-import { fetchEncodedImage } from './default-fetcher'
+import { fetchEncodedImage } from './image-fetcher'
 import { formatEncodedImage } from './format-image'
 import { BackendImageRecord } from '../shared/models/backend-image-record'
 

--- a/src/shared/image-encoder.ts
+++ b/src/shared/image-encoder.ts
@@ -28,6 +28,11 @@ export const encodeImagePayload = (payload: ImagePayload): Uint8Array => {
  * Expects: [format (1 byte)] [token (8 bytes, LE)] [buffer]
  */
 export const decodeImagePayload = (data: Uint8Array): ImagePayload => {
+  // Sanity check: payload must include format(1) + token(8)
+  if (data.length < 9) {
+    throw new Error('Invalid payload: too short')
+  }
+
   const formatByte = data[0]
   const imageFormat = byteToImageFormat(formatByte)
   const token = Number(

--- a/tests/modules/frontend/custom-image-fetcher.test.ts
+++ b/tests/modules/frontend/custom-image-fetcher.test.ts
@@ -1,0 +1,17 @@
+import {
+  registerCustomImageFetcher,
+  getCustomImageFetcher,
+} from '../../../src/frontend/custom-image-fetcher'
+
+describe('custom-image-fetcher', () => {
+  it('registers and retrieves a custom fetcher', () => {
+    const fetcher = async (_: string) => new Uint8Array([1])
+    registerCustomImageFetcher(fetcher)
+    expect(getCustomImageFetcher()).toBe(fetcher)
+  })
+
+  it('returns undefined if no custom fetcher is registered', () => {
+    registerCustomImageFetcher(undefined as any)
+    expect(getCustomImageFetcher()).toBeUndefined()
+  })
+})

--- a/tests/modules/frontend/default-image-fetcher.test.ts
+++ b/tests/modules/frontend/default-image-fetcher.test.ts
@@ -3,7 +3,7 @@ import {
   stopDefaultEndpoint,
 } from '../../../src/backend/default-endpoint'
 import { saveImageFromFile } from '../../../src/backend/image-service'
-import { fetchEncodedImage } from '../../../src/frontend/default-fetcher'
+import { fetchEncodedImage } from '../../../src/frontend/image-fetcher'
 import { decodeImagePayload } from '../../../src/shared/image-encoder'
 import fs from 'fs/promises'
 import path from 'path'

--- a/tests/modules/frontend/image-fetcher.test.ts
+++ b/tests/modules/frontend/image-fetcher.test.ts
@@ -1,0 +1,28 @@
+import { fetchEncodedImage } from '../../../src/frontend/image-fetcher'
+import { registerCustomImageFetcher } from '../../../src/frontend/custom-image-fetcher'
+import * as defaultFetcherModule from '../../../src/frontend/default-image-fetcher'
+
+describe('fetchEncodedImage', () => {
+  const testId = 'abc123'
+  const defaultData = new Uint8Array([42])
+  const customData = new Uint8Array([99])
+  it('uses default fetcher if no custom fetcher is registered', async () => {
+    jest
+      .spyOn(defaultFetcherModule, 'getDefaultImageFetcher')
+      .mockReturnValue(async (id: string) => {
+        expect(id).toBe(testId)
+        return defaultData
+      })
+    const result = await fetchEncodedImage(testId)
+    expect(result).toEqual(defaultData)
+  })
+
+  it('uses custom fetcher if registered', async () => {
+    registerCustomImageFetcher(async (id) => {
+      expect(id).toBe(testId)
+      return customData
+    })
+    const result = await fetchEncodedImage(testId)
+    expect(result).toEqual(customData)
+  })
+})


### PR DESCRIPTION
- Adds registerCustomImageFetcher() and getCustomImageFetcher() for user-defined fetch logic
- Splits default-image-fetcher, custom-image-fetcher, and image-fetcher as central entry point
- All fetch logic routed through fetchEncodedImage() for consistent API
- Includes isolated tests for default, custom, and fetch selection logic

Closes #22