### PR TITLE
feat: implement LRU cache cleanup for IndexedDB image store

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,3 +43,7 @@ export const FRONTEND_DB_VERSION = 1
 export const IMAGE_STORE_NAME = 'images'
 
 export const TEMP_IMAGE_STORE_NAME = 'images_temp'
+
+export const FRONTEND_IMAGE_CACHE_LIMIT = IS_TEST ? 50 : 1000
+
+export const FRONTEND_CLEANUP_BATCH = IS_TEST ? 5 : 50

--- a/src/frontend/cleanup.ts
+++ b/src/frontend/cleanup.ts
@@ -1,0 +1,31 @@
+import {
+  getImageRecordCount,
+  getAllImageRecords,
+  deleteImageRecords,
+} from './database'
+import {
+  FRONTEND_IMAGE_CACHE_LIMIT,
+  FRONTEND_CLEANUP_BATCH,
+} from '../constants'
+
+/**
+ * Removes the oldest cached images if the cache limit is exceeded.
+ * Uses an LRU (least recently used) policy based on the 'lastUsed' field.
+ */
+export const cleanupImageCache = async (): Promise<void> => {
+  // 1. Get the current cache size
+  const totalImages = await getImageRecordCount()
+  if (totalImages <= FRONTEND_IMAGE_CACHE_LIMIT) return
+
+  // 2. Fetch all records
+  const allRecords = await getAllImageRecords()
+  // 3. Sort records by lastUsed (oldest first)
+  allRecords.sort((a, b) => a.lastUsed - b.lastUsed)
+  // 4. Select the oldest N records for deletion
+  const deletingRecords = allRecords
+    .slice(0, FRONTEND_CLEANUP_BATCH)
+    .map((record) => record.id)
+
+  // 5. Delete them in a single transaction
+  await deleteImageRecords(deletingRecords)
+}

--- a/tests/modules/frontend/cleanup.test.ts
+++ b/tests/modules/frontend/cleanup.test.ts
@@ -1,0 +1,64 @@
+import 'fake-indexeddb/auto'
+import {
+  writeImageRecord,
+  getAllImageRecords,
+  getImageRecordCount,
+  deleteImageRecords,
+} from '../../../src/frontend/database'
+import { cleanupImageCache } from '../../../src/frontend/cleanup'
+import {
+  FRONTEND_IMAGE_CACHE_LIMIT,
+  FRONTEND_CLEANUP_BATCH,
+} from '../../../src/constants'
+import { sleep } from '../../utils'
+
+const makeRecord = (id: string, offsetMs: number) => ({
+  id,
+  data: new Blob(['img'], { type: 'image/png' }),
+  token: Math.floor(Math.random() * 1e6),
+  lastUsed: Date.now() - offsetMs,
+})
+
+describe('cleanupImageCache auto‐cleanup behavior', () => {
+  beforeEach(async () => {
+    // ensure a clean slate
+    const all = await getAllImageRecords()
+    if (all.length > 0) {
+      await deleteImageRecords(all.map((r) => r.id))
+    }
+  })
+
+  it(`automatically removes the oldest ${FRONTEND_CLEANUP_BATCH} records when limit exceeded`, async () => {
+    const totalToAdd = FRONTEND_IMAGE_CACHE_LIMIT + FRONTEND_CLEANUP_BATCH
+
+    // 1) insert totalToAdd records with oldest first
+    for (let i = 0; i < totalToAdd; i++) {
+      await writeImageRecord(makeRecord(`item-${i}`, (totalToAdd - i) * 100))
+      await sleep(1)
+    }
+
+    // give background cleanup a moment to run
+    await sleep(20)
+
+    // 2) after writes, cache should have been auto‐cleaned down to the limit
+    const countAfterAuto = await getImageRecordCount()
+    expect(countAfterAuto).toBe(FRONTEND_IMAGE_CACHE_LIMIT)
+
+    const remaining = await getAllImageRecords()
+    const ids = remaining.map((r) => r.id)
+
+    // 3) verify the oldest batch were removed
+    for (let i = 0; i < FRONTEND_CLEANUP_BATCH; i++) {
+      expect(ids).not.toContain(`item-${i}`)
+    }
+
+    // 4) verify that all newer records remain
+    for (let i = FRONTEND_CLEANUP_BATCH; i < totalToAdd; i++) {
+      expect(ids).toContain(`item-${i}`)
+    }
+
+    // 5) calling cleanupImageCache again should not change anything
+    await cleanupImageCache()
+    expect(await getImageRecordCount()).toBe(FRONTEND_IMAGE_CACHE_LIMIT)
+  })
+})

--- a/tests/modules/frontend/database.test.ts
+++ b/tests/modules/frontend/database.test.ts
@@ -4,8 +4,13 @@ import {
   readImageRecord,
   deleteImageRecord,
   imageRecordExists,
+  getAllImageRecords,
+  deleteImageRecords,
+  getImageRecordCount,
 } from '../../../src/frontend/database'
 import { FrontendImageRecord } from '../../../src/shared/models/frontend-image-record'
+
+const fakeBlob = new Blob(['test'], { type: 'image/png' })
 
 describe('Frontend Database CRUD', () => {
   const id = 'city:1232323'
@@ -60,5 +65,84 @@ describe('Frontend Database CRUD', () => {
     const res = await readImageRecord(id)
     expect(res).toBeNull()
     expect(await imageRecordExists(id)).toBe(false)
+  })
+})
+
+describe('getImageRecordCount', () => {
+  it('returns 0 when no records exist', async () => {
+    // Benzersiz id eklemeden önce tüm kayıtları sil
+    const records = await getAllImageRecords()
+    if (records.length > 0) {
+      const ids = records.map((r) => r.id)
+      await deleteImageRecords(ids)
+    }
+    const count = await getImageRecordCount()
+    expect(count).toBe(0)
+  })
+
+  it('returns correct count after adding records', async () => {
+    await writeImageRecord({
+      id: 'count-1',
+      token: 1,
+      data: fakeBlob,
+      lastUsed: Date.now(),
+    })
+    await writeImageRecord({
+      id: 'count-2',
+      token: 2,
+      data: fakeBlob,
+      lastUsed: Date.now(),
+    })
+    const count = await getImageRecordCount()
+    expect(count).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe('getAllImageRecords', () => {
+  it('returns all records that were added', async () => {
+    await writeImageRecord({
+      id: 'all-1',
+      token: 1,
+      data: fakeBlob,
+      lastUsed: Date.now(),
+    })
+    await writeImageRecord({
+      id: 'all-2',
+      token: 2,
+      data: fakeBlob,
+      lastUsed: Date.now(),
+    })
+    const records = await getAllImageRecords()
+    const ids = records.map((r) => r.id)
+    expect(ids).toContain('all-1')
+    expect(ids).toContain('all-2')
+  })
+})
+
+describe('deleteImageRecords', () => {
+  it('deletes specified records in a single transaction', async () => {
+    await writeImageRecord({
+      id: 'del-1',
+      token: 11,
+      data: fakeBlob,
+      lastUsed: Date.now(),
+    })
+    await writeImageRecord({
+      id: 'del-2',
+      token: 12,
+      data: fakeBlob,
+      lastUsed: Date.now(),
+    })
+    await deleteImageRecords(['del-1', 'del-2'])
+    const records = await getAllImageRecords()
+    const ids = records.map((r) => r.id)
+    expect(ids).not.toContain('del-1')
+    expect(ids).not.toContain('del-2')
+  })
+
+  it('does not throw if records do not exist', async () => {
+    await expect(
+      deleteImageRecords(['nonexistent-1', 'nonexistent-2']),
+    ).resolves.not.toThrow()
   })
 })


### PR DESCRIPTION
- Added cleanupImageCache function with LRU batch eviction (uses lastUsed)
- Enforces cache limit using FRONTEND_IMAGE_CACHE_LIMIT and FRONTEND_CLEANUP_BATCH
- Updated writeImageRecord to trigger cleanup after each insert/update
- Added and refactored tests for batch cleanup and cache behavior

Closes #6