### PR TITLE
feat: add runtime init/config system and main index.ts entrypoint

### DIFF
--- a/src/backend/database.ts
+++ b/src/backend/database.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3'
 
-import { BackendImageRecord } from '../shared/models/backend-image-record'
+import { ImageRecord } from '../shared/models/image-record'
 import { pixstoreConfig } from '../shared/pixstore-config'
 
 const DATABASE_PATH = pixstoreConfig.databasePath
@@ -20,7 +20,7 @@ database.exec(
  * Inserts or updates an image record with the given ID.
  * If the ID already exists, the token is updated.
  */
-export const writeImageRecord = (id: string): BackendImageRecord => {
+export const writeImageRecord = (id: string): ImageRecord => {
   const token = Date.now()
   const statement = database.prepare(
     `INSERT INTO image_records (id, token)
@@ -36,11 +36,11 @@ export const writeImageRecord = (id: string): BackendImageRecord => {
  * Retrieves the image record with the given ID.
  * Returns null if the record does not exist.
  */
-export const readImageRecord = (id: string): BackendImageRecord | null => {
+export const readImageRecord = (id: string): ImageRecord | null => {
   const row = database
     .prepare(`SELECT id, token FROM image_records WHERE id = ?`)
     .get(id)
-  return row ? (row as BackendImageRecord) : null
+  return row ? (row as ImageRecord) : null
 }
 
 /**

--- a/src/backend/image-service.ts
+++ b/src/backend/image-service.ts
@@ -12,7 +12,7 @@ import {
   writeImageRecord,
 } from './database'
 import { createUniqueId } from './unique-id'
-import type { BackendImageRecord } from '../shared/models/backend-image-record'
+import type { ImageRecord } from '../shared/models/image-record'
 import { ImagePayload } from '../shared/models/image-payload'
 import { getImageFormat } from './format-image'
 
@@ -39,7 +39,7 @@ const writeImage = async (
   id: string,
   buffer: Buffer,
   dir?: string,
-): Promise<BackendImageRecord> => {
+): Promise<ImageRecord> => {
   await saveImageFile(id, buffer)
   try {
     return writeImageRecord(id)
@@ -56,7 +56,7 @@ const writeImage = async (
 export const saveImage = async (
   buffer: Buffer,
   dir?: string,
-): Promise<BackendImageRecord> => {
+): Promise<ImageRecord> => {
   const id = createUniqueId(dir)
   return await writeImage(id, buffer, dir)
 }
@@ -68,7 +68,7 @@ export const saveImage = async (
 export const saveImageFromFile = async (
   filePath: string,
   dir?: string,
-): Promise<BackendImageRecord> => {
+): Promise<ImageRecord> => {
   const buffer = await diskToBuffer(filePath)
   return await saveImage(buffer, dir)
 }
@@ -81,7 +81,7 @@ export const updateImage = async (
   id: string,
   buffer: Buffer,
   dir?: string,
-): Promise<BackendImageRecord> => {
+): Promise<ImageRecord> => {
   if (!imageRecordExists(id)) {
     throw new Error(`Image not found: ${id}`)
   }
@@ -96,7 +96,7 @@ export const updateImageFromFile = async (
   id: string,
   filePath: string,
   dir?: string,
-): Promise<BackendImageRecord> => {
+): Promise<ImageRecord> => {
   const buffer = await diskToBuffer(filePath)
   return await updateImage(id, buffer, dir)
 }
@@ -125,7 +125,7 @@ export const deleteImage = async (id: string): Promise<boolean> => {
  * Returns the image record (id + token) from the database.
  * Returns null if not found.
  */
-export const getImageRecord = (id: string): BackendImageRecord | null => {
+export const getImageRecord = (id: string): ImageRecord | null => {
   return readImageRecord(id)
 }
 

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,0 +1,27 @@
+import { PixstoreBackendConfig } from '../shared/models/pixstore-config'
+import { initPixstore, pixstoreConfig } from '../shared/pixstore-config'
+import { startDefaultEndpoint } from './default-endpoint'
+
+export const initPixstoreBackend = (
+  config: Partial<PixstoreBackendConfig> = {},
+) => {
+  initPixstore(config)
+  if (pixstoreConfig.defaultEndpointEnabled) {
+    startDefaultEndpoint()
+  }
+}
+
+export {
+  getImageRecord,
+  saveImage,
+  saveImageFromFile,
+  updateImage,
+  updateImageFromFile,
+  deleteImage,
+  imageExists,
+  getImage,
+} from './image-service'
+
+export type { ImageRecord } from '../shared/models/image-record'
+
+export { customEndpointHelper } from './custom-endpoint'

--- a/src/frontend/image-service.ts
+++ b/src/frontend/image-service.ts
@@ -5,13 +5,13 @@ import {
 } from './database'
 import { fetchEncodedImage } from './image-fetcher'
 import { formatEncodedImage } from './format-image'
-import { BackendImageRecord } from '../shared/models/backend-image-record'
+import { ImageRecord } from '../shared/models/image-record'
 
 /**
  * Retrieves image data using token-based cache validation.
  * Returns the cached Blob if token matches; otherwise fetches, updates, and returns new Blob.
  */
-export const getImage = async (record: BackendImageRecord): Promise<Blob> => {
+export const getImage = async (record: ImageRecord): Promise<Blob> => {
   // Attempt to read the cached image from IndexedDB by ID
   const cached = await readImageRecord(record.id)
 

--- a/src/shared/models/backend-image-record.ts
+++ b/src/shared/models/backend-image-record.ts
@@ -1,4 +1,0 @@
-export interface BackendImageRecord {
-  id: string
-  token: number
-}

--- a/src/shared/models/image-record.ts
+++ b/src/shared/models/image-record.ts
@@ -1,0 +1,4 @@
+export interface ImageRecord {
+  id: string
+  token: number
+}

--- a/src/shared/models/pixstore-config.ts
+++ b/src/shared/models/pixstore-config.ts
@@ -1,19 +1,29 @@
 import { ImageFormat } from './image-format'
 
-export interface PixstoreConfig {
+export interface PixstoreBackendConfig {
   imageFormats: readonly ImageFormat[]
-  imageFormatToByte: Map<ImageFormat, number>
-  byteToImageFormat: Map<number, ImageFormat>
-  imageExtension: string
   imageRootDir: string
+  databasePath: string
   defaultEndpointHost: string
-  serverHost: string
+  defaultEndpointEnabled: boolean
   defaultEndpointPort: number
   defaultEndpointRoute: string
-  databasePath: string
+}
+
+export interface PixstoreFrontendConfig {
+  imageFormats: readonly ImageFormat[]
   frontendDbName: string
+  serverHost: string
   frontendDbVersion: number
   imageStoreName: string
   frontendImageCacheLimit: number
   frontendCleanupBatch: number
+}
+
+export interface PixstoreConfig
+  extends PixstoreBackendConfig,
+    PixstoreFrontendConfig {
+  imageFormatToByte: Map<ImageFormat, number>
+  byteToImageFormat: Map<number, ImageFormat>
+  imageExtension: string
 }

--- a/src/shared/pixstore-config.ts
+++ b/src/shared/pixstore-config.ts
@@ -73,13 +73,16 @@ export const defaultConfig: PixstoreConfig = {
   ...buildFormatMaps(DEFAULT_IMAGE_FORMATS),
   imageExtension: '.pixstore-image',
   imageRootDir: IS_TEST ? 'pixstore-test-images' : 'pixstore-images',
+
+  databasePath: IS_TEST ? './.pixstore-test.sqlite' : './.pixstore.sqlite',
   defaultEndpointHost: IS_TEST ? '127.0.0.1' : '0.0.0.0',
-  serverHost: IS_TEST ? '127.0.0.1' : 'unknown',
+  defaultEndpointEnabled: true,
   defaultEndpointPort: IS_TEST
     ? 10000 + Math.floor(Math.random() * 50000)
     : 3001,
   defaultEndpointRoute: '/pixstore-image',
-  databasePath: IS_TEST ? './.pixstore-test.sqlite' : './.pixstore.sqlite',
+
+  serverHost: IS_TEST ? '127.0.0.1' : 'unknown',
   frontendDbName: IS_TEST ? 'pixstore-test' : 'pixstore',
   frontendDbVersion: 1,
   imageStoreName: 'images',
@@ -98,7 +101,7 @@ export const pixstoreConfig: PixstoreConfig = { ...defaultConfig }
  * Safe to call multiple times; always merges on top of previous config.
  * If imageFormats is changed, encoding maps are automatically updated.
  */
-export function initPixstore(config: Partial<PixstoreConfig> = {}) {
+export const initPixstore = (config: Partial<PixstoreConfig> = {}) => {
   validateConfig(config)
   let maps = {}
   if (config.imageFormats) {

--- a/tests/modules/frontend/default-image-fetcher.test.ts
+++ b/tests/modules/frontend/default-image-fetcher.test.ts
@@ -7,13 +7,13 @@ import { fetchEncodedImage } from '../../../src/frontend/image-fetcher'
 import { decodeImagePayload } from '../../../src/shared/image-encoder'
 import fs from 'fs/promises'
 import path from 'path'
-import { BackendImageRecord } from '../../../src/shared/models/backend-image-record'
+import { ImageRecord } from '../../../src/shared/models/image-record'
 
 const assetsDir = path.resolve(__dirname, '../../assets')
 const TEST_IMAGE_PATH = path.join(assetsDir, 'antalya.jpg')
 
 describe('fetchEncodedImage (integration)', () => {
-  let record: BackendImageRecord
+  let record: ImageRecord
   beforeAll(async () => {
     record = await saveImageFromFile(TEST_IMAGE_PATH)
   })

--- a/tests/modules/frontend/image-service.test.ts
+++ b/tests/modules/frontend/image-service.test.ts
@@ -1,7 +1,7 @@
 import 'fake-indexeddb/auto'
 import path from 'path'
 import fs from 'fs/promises'
-import { BackendImageRecord } from '../../../src/shared/models/backend-image-record'
+import { ImageRecord } from '../../../src/shared/models/image-record'
 import {
   getImage,
   getCachedImage,
@@ -26,7 +26,7 @@ const expectBlobsToBeEqual = async (a: Blob, b: Blob) => {
 }
 
 describe('frontend image-service – full flow', () => {
-  let record: BackendImageRecord
+  let record: ImageRecord
 
   beforeAll(async () => {
     startDefaultEndpoint()


### PR DESCRIPTION
- Implements dynamic runtime configuration for backend module
- Adds single initPixstoreBackend entrypoint that applies user config and auto-starts endpoint if enabled
- Removes direct constant imports in favor of config-driven access
- Exports only public, stable API surface for backend users
- Ensures backward compatibility and sensible defaults

Closes #33