### PR TITLE
fix: properly initialize database in backend and tests

### DIFF
--- a/src/backend/default-endpoint.ts
+++ b/src/backend/default-endpoint.ts
@@ -12,10 +12,6 @@ import { getImage } from './image-service.js'
 import { encodeImagePayload } from '../shared/image-encoder.js'
 import { pixstoreConfig, IS_TEST } from '../shared/pixstore-config.js'
 
-const DEFAULT_ENDPOINT_HOST = pixstoreConfig.defaultEndpointHost
-const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointPort
-const DEFAULT_ENDPOINT_ROUTE = pixstoreConfig.defaultEndpointRoute
-
 let server: http.Server
 
 /**
@@ -27,6 +23,8 @@ const requestHandler = (
   req: http.IncomingMessage,
   res: http.ServerResponse,
 ) => {
+  const DEFAULT_ENDPOINT_ROUTE = pixstoreConfig.defaultEndpointRoute
+
   // Only allow GET requests
   if (!req.url || req.method !== 'GET') {
     res.writeHead(404).end('Not found')
@@ -72,12 +70,15 @@ const requestHandler = (
  * - Suppresses console output in test mode.
  * - Uses `unref()` so Jest or other processes can exit cleanly.
  */
-export const startDefaultEndpoint = (port = DEFAULT_ENDPOINT_PORT): void => {
+export const startDefaultEndpoint = (): void => {
+  const DEFAULT_ENDPOINT_HOST = pixstoreConfig.defaultEndpointHost
+  const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointPort
+
   if (server) return
 
   server = http
     .createServer(requestHandler)
-    .listen(port, DEFAULT_ENDPOINT_HOST, () => {
+    .listen(DEFAULT_ENDPOINT_PORT, DEFAULT_ENDPOINT_HOST, () => {
       if (!IS_TEST) {
         console.log(
           `Pixstore endpoint listening on ${DEFAULT_ENDPOINT_HOST}:${DEFAULT_ENDPOINT_PORT}`,

--- a/src/backend/format-image.ts
+++ b/src/backend/format-image.ts
@@ -2,15 +2,12 @@ import { pixstoreConfig } from '../shared/pixstore-config.js'
 import imageType from 'image-type'
 import type { ImageFormat } from '../models/image-format.js'
 
-const BYTE_TO_IMAGE_FORMAT = pixstoreConfig.byteToImageFormat
-const IMAGE_FORMATS = pixstoreConfig.imageFormats
-const IMAGE_FORMAT_TO_BYTE = pixstoreConfig.imageFormatToByte
-
 /**
  * Converts an ImageFormat string (e.g., 'jpeg', 'png') to its protocol byte value.
  * Returns 0 for unknown/unsupported formats.
  */
 export const imageFormatToByte = (format: ImageFormat): number => {
+  const IMAGE_FORMAT_TO_BYTE = pixstoreConfig.imageFormatToByte
   const byte = IMAGE_FORMAT_TO_BYTE.get(format)
   if (byte === undefined) {
     throw new Error(`Unsupported image format: ${format}`)
@@ -23,6 +20,7 @@ export const imageFormatToByte = (format: ImageFormat): number => {
  * Returns the first entry of IMAGE_FORMATS as fallback if the byte is invalid.
  */
 export const byteToImageFormat = (byte: number): ImageFormat => {
+  const BYTE_TO_IMAGE_FORMAT = pixstoreConfig.byteToImageFormat
   const format = BYTE_TO_IMAGE_FORMAT.get(byte)
   if (format === undefined) {
     throw new Error(`Unknown image format byte: ${byte}`)
@@ -33,6 +31,7 @@ export const byteToImageFormat = (byte: number): ImageFormat => {
  * Checks if the given buffer is a valid image of supported type.
  */
 export const isValidImage = (buffer: Buffer): boolean => {
+  const IMAGE_FORMATS = pixstoreConfig.imageFormats
   const type = imageType(buffer)
   return (
     !!type && IMAGE_FORMATS.includes(type.ext as (typeof IMAGE_FORMATS)[number])
@@ -44,6 +43,7 @@ export const isValidImage = (buffer: Buffer): boolean => {
  * Throws if format is missing or unsupported.
  */
 export const getImageFormat = (buffer: Buffer): ImageFormat => {
+  const IMAGE_FORMATS = pixstoreConfig.imageFormats
   const type = imageType(buffer)
   if (!type || !IMAGE_FORMATS.includes(type.ext as ImageFormat)) {
     throw new Error('Unsupported or invalid image format')

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,5 +1,6 @@
 import type { PixstoreBackendConfig } from '../models/pixstore-config.js'
 import { initPixstore, pixstoreConfig } from '../shared/pixstore-config.js'
+import { initializeDatabase } from './database.js'
 import { startDefaultEndpoint } from './default-endpoint.js'
 
 /**
@@ -10,6 +11,7 @@ export const initPixstoreBackend = (
   config: Partial<PixstoreBackendConfig> = {},
 ) => {
   initPixstore(config)
+  initializeDatabase()
   if (pixstoreConfig.defaultEndpointEnabled) {
     startDefaultEndpoint()
   }

--- a/src/backend/unique-id.ts
+++ b/src/backend/unique-id.ts
@@ -1,9 +1,6 @@
 import { pixstoreConfig } from '../shared/pixstore-config.js'
 import { imageRecordExists } from './database.js'
 
-const IMAGE_ROOT_DIR = pixstoreConfig.imageRootDir
-const IMAGE_EXTENSION = pixstoreConfig.imageExtension
-
 /**
  * Generates a unique image ID with optional directory prefix.
  * Example: students:kth1m9c4n8l2a7vz
@@ -34,6 +31,9 @@ export const createUniqueId = (dir?: string): string => {
  * Example: students:kth1m9c4n8l2a7vz → images/students/kth1m9c4n8l2a7vz.webp
  */
 export const toFilePath = (id: string): string => {
+  const IMAGE_ROOT_DIR = pixstoreConfig.imageRootDir
+  const IMAGE_EXTENSION = pixstoreConfig.imageExtension
+
   const [prefix, key] = id.split(':')
   if (!prefix || !key) return `${IMAGE_ROOT_DIR}/${id}${IMAGE_EXTENSION}`
   return `${IMAGE_ROOT_DIR}/${prefix}/${key}${IMAGE_EXTENSION}`

--- a/src/frontend/cleanup.ts
+++ b/src/frontend/cleanup.ts
@@ -5,13 +5,13 @@ import {
 } from './database.js'
 import { pixstoreConfig } from '../shared/pixstore-config.js'
 
-const FRONTEND_IMAGE_CACHE_LIMIT = pixstoreConfig.frontendImageCacheLimit
-const FRONTEND_CLEANUP_BATCH = pixstoreConfig.frontendCleanupBatch
 /**
  * Removes the oldest cached images if the cache limit is exceeded.
  * Uses an LRU (least recently used) policy based on the 'lastUsed' field.
  */
 export const cleanupImageCache = async (): Promise<void> => {
+  const FRONTEND_IMAGE_CACHE_LIMIT = pixstoreConfig.frontendImageCacheLimit
+  const FRONTEND_CLEANUP_BATCH = pixstoreConfig.frontendCleanupBatch
   // 1. Get the current cache size
   const totalImages = await getImageRecordCount()
   if (totalImages <= FRONTEND_IMAGE_CACHE_LIMIT) return

--- a/src/frontend/database.ts
+++ b/src/frontend/database.ts
@@ -3,10 +3,6 @@ import { cleanupImageCache } from './cleanup.js'
 
 import { pixstoreConfig } from '../shared/pixstore-config.js'
 
-const FRONTEND_DB_NAME = pixstoreConfig.frontendDbName
-const FRONTEND_DB_VERSION = pixstoreConfig.frontendDbVersion
-const IMAGE_STORE_NAME = pixstoreConfig.imageStoreName
-
 let database: IDBDatabase | null = null
 
 /**
@@ -16,6 +12,9 @@ let database: IDBDatabase | null = null
  * Returns a promise that resolves to the IDBDatabase connection.
  */
 export const openDatabase = (): Promise<IDBDatabase> => {
+  const FRONTEND_DB_NAME = pixstoreConfig.frontendDbName
+  const FRONTEND_DB_VERSION = pixstoreConfig.frontendDbVersion
+  const IMAGE_STORE_NAME = pixstoreConfig.imageStoreName
   if (database) return Promise.resolve(database)
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(FRONTEND_DB_NAME, FRONTEND_DB_VERSION)
@@ -42,6 +41,7 @@ export const openDatabase = (): Promise<IDBDatabase> => {
 export const getImageStore = async (
   mode: IDBTransactionMode = 'readonly',
 ): Promise<{ transaction: IDBTransaction; store: IDBObjectStore }> => {
+  const IMAGE_STORE_NAME = pixstoreConfig.imageStoreName
   const database = await openDatabase()
   const transaction = database.transaction(IMAGE_STORE_NAME, mode)
   const store = transaction.objectStore(IMAGE_STORE_NAME)

--- a/src/frontend/default-image-fetcher.ts
+++ b/src/frontend/default-image-fetcher.ts
@@ -1,9 +1,5 @@
 import { pixstoreConfig } from '../shared/pixstore-config.js'
 
-const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointPort
-const DEFAULT_ENDPOINT_ROUTE = pixstoreConfig.defaultEndpointRoute
-const SERVER_HOST = pixstoreConfig.defaultEndpointHost
-
 /**
  * Fetches a raw encoded image payload from the Pixstore backend.
  *
@@ -11,6 +7,9 @@ const SERVER_HOST = pixstoreConfig.defaultEndpointHost
  * the wire format protocol: [1 byte format][8 byte token][N bytes buffer].
  */
 const defaultImageFetcher = async (id: string): Promise<Uint8Array> => {
+  const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointPort
+  const DEFAULT_ENDPOINT_ROUTE = pixstoreConfig.defaultEndpointRoute
+  const SERVER_HOST = pixstoreConfig.defaultEndpointHost
   // Construct the full URL using constants
   const url = `http://${SERVER_HOST}:${DEFAULT_ENDPOINT_PORT}${DEFAULT_ENDPOINT_ROUTE}/${encodeURIComponent(id)}`
 

--- a/src/frontend/format-image.ts
+++ b/src/frontend/format-image.ts
@@ -3,12 +3,12 @@ import type { FrontendImageRecord } from '../models/frontend-image-record.js'
 import type { ImageFormat } from '../models/image-format.js'
 import { pixstoreConfig } from '../shared/pixstore-config.js'
 
-const IMAGE_FORMATS = pixstoreConfig.imageFormats
 /**
  * Converts an image format (e.g. 'png') to the corresponding MIME type.
  * Throws if the format is not supported.
  */
 const imageFormatToMime = (format: ImageFormat): string => {
+  const IMAGE_FORMATS = pixstoreConfig.imageFormats
   if (!IMAGE_FORMATS.includes(format))
     throw new Error(`Unsupported image format: ${format}`)
   return `image/${format}`

--- a/tests/modules/backend/custom-endpoint.test.ts
+++ b/tests/modules/backend/custom-endpoint.test.ts
@@ -7,6 +7,7 @@ import { saveImage } from '../../../src/backend/image-service.js'
 import fs from 'fs/promises'
 import path from 'path'
 import { sleep } from '../../utils.js'
+import { initializeDatabase } from '../../../src/backend/database.js'
 
 const assetDir = path.resolve(__dirname, '../../assets')
 const ANTALYA_PATH = path.join(assetDir, 'antalya.jpg')
@@ -15,6 +16,7 @@ describe('customEndpointHelper', () => {
   let id: string
 
   beforeAll(async () => {
+    initializeDatabase()
     // Save a test image to backend and keep the ID
     const saved = await saveImage(await fs.readFile(ANTALYA_PATH), 'students')
     id = saved.id

--- a/tests/modules/backend/database.test.ts
+++ b/tests/modules/backend/database.test.ts
@@ -3,6 +3,7 @@ import {
   readImageRecord,
   deleteImageRecord,
   imageRecordExists,
+  initializeDatabase,
 } from '../../../src/backend/database.js'
 
 import fs from 'fs'
@@ -15,6 +16,7 @@ const dbPath =
 
 describe('firstWrite', () => {
   it('creates storage directory on first write', () => {
+    initializeDatabase()
     writeImageRecord('first-write')
     expect(fs.existsSync(dbPath)).toBe(true)
   })
@@ -24,6 +26,7 @@ describe('readImageRecord', () => {
   const testId = 'read-test'
 
   beforeAll(() => {
+    initializeDatabase()
     writeImageRecord(testId)
   })
 

--- a/tests/modules/backend/default-endpoint.test.ts
+++ b/tests/modules/backend/default-endpoint.test.ts
@@ -13,11 +13,15 @@ import {
 } from '../../../src/backend/default-endpoint'
 
 import { pixstoreConfig } from '../../../src/shared/pixstore-config'
+import { initializeDatabase } from '../../../src/backend/database'
 const DEFAULT_ENDPOINT_HOST = pixstoreConfig.defaultEndpointHost
 const DEFAULT_ENDPOINT_ROUTE = pixstoreConfig.defaultEndpointRoute
 const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointPort
 
-beforeAll(() => startDefaultEndpoint())
+beforeAll(() => {
+  initializeDatabase()
+  startDefaultEndpoint()
+})
 afterAll(async () => await stopDefaultEndpoint())
 
 const BASE_URL = `http://${DEFAULT_ENDPOINT_HOST}:${DEFAULT_ENDPOINT_PORT}`

--- a/tests/modules/backend/image-service.test.ts
+++ b/tests/modules/backend/image-service.test.ts
@@ -8,10 +8,17 @@ import {
   saveImageFromFile,
   updateImageFromFile,
 } from '../../../src/backend/image-service'
-import { readImageRecord } from '../../../src/backend/database'
+import {
+  initializeDatabase,
+  readImageRecord,
+} from '../../../src/backend/database'
 import { toFilePath } from '../../../src/backend/unique-id'
 
 const assetsDir = path.resolve(__dirname, '../../assets')
+
+beforeAll(() => {
+  initializeDatabase()
+})
 
 describe('saveImageFromFile', () => {
   const testDir = 'saveImageFromFile'

--- a/tests/modules/backend/unique-id.test.ts
+++ b/tests/modules/backend/unique-id.test.ts
@@ -1,8 +1,13 @@
+import { initializeDatabase } from '../../../src/backend/database'
 import { createUniqueId, toFilePath } from '../../../src/backend/unique-id'
 
 import { pixstoreConfig } from '../../../src/shared/pixstore-config'
 const IMAGE_ROOT_DIR = pixstoreConfig.imageRootDir
 const IMAGE_EXTENSION = pixstoreConfig.imageExtension
+
+beforeAll(() => {
+  initializeDatabase()
+})
 
 describe('createUniqueId', () => {
   it('generates a unique ID as a string', () => {

--- a/tests/modules/frontend/default-image-fetcher.test.ts
+++ b/tests/modules/frontend/default-image-fetcher.test.ts
@@ -8,9 +8,14 @@ import { decodeImagePayload } from '../../../src/shared/image-encoder'
 import fs from 'fs/promises'
 import path from 'path'
 import { ImageRecord } from '../../../src/models/image-record'
+import { initializeDatabase } from '../../../src/backend/database'
 
 const assetsDir = path.resolve(__dirname, '../../assets')
 const TEST_IMAGE_PATH = path.join(assetsDir, 'antalya.jpg')
+
+beforeAll(() => {
+  initializeDatabase()
+})
 
 describe('fetchEncodedImage (integration)', () => {
   let record: ImageRecord

--- a/tests/modules/frontend/image-service.test.ts
+++ b/tests/modules/frontend/image-service.test.ts
@@ -13,6 +13,7 @@ import {
   stopDefaultEndpoint,
 } from '../../../src/backend/default-endpoint'
 import { saveImage, updateImage } from '../../../src/backend/image-service'
+import { initializeDatabase } from '../../../src/backend/database'
 
 const assetDir = path.resolve(__dirname, '../../assets')
 const ANTALYA_PATH = path.join(assetDir, 'antalya.jpg')
@@ -24,6 +25,9 @@ const expectBlobsToBeEqual = async (a: Blob, b: Blob) => {
   const bufB = Buffer.from(await b.arrayBuffer())
   expect(Buffer.compare(bufA, bufB)).toBe(0)
 }
+beforeAll(() => {
+  initializeDatabase()
+})
 
 describe('frontend image-service – full flow', () => {
   let record: ImageRecord

--- a/tests/scenario/backend-image-highload.test.ts
+++ b/tests/scenario/backend-image-highload.test.ts
@@ -6,11 +6,16 @@ import {
   updateImage,
 } from '../../src/backend/image-service'
 import fs from 'fs'
+import { initializeDatabase } from '../../src/backend/database'
 
 const assetsDir = path.resolve(__dirname, '../assets')
 const imageFile = path.join(assetsDir, 'antalya.jpg')
 const imageFile2 = path.join(assetsDir, 'vilnius.jpg')
 const N = 100
+
+beforeAll(() => {
+  initializeDatabase()
+})
 
 describe('Pixstore backend highload scenario', () => {
   const prefix = 'stress'


### PR DESCRIPTION
- Move database initialization to initPixstoreBackend for consistent setup
- Add initializeDatabase call in beforeAll hooks in tests to fix failures
- Update imports and usage of pixstoreConfig for direct reference
- Fix import extensions and module resolution for ESM compatibility