### PR TITLE
feat: support optional context parameter in custom image fetcher

### DIFF
--- a/src/frontend/custom-image-fetcher.ts
+++ b/src/frontend/custom-image-fetcher.ts
@@ -1,14 +1,16 @@
+import type { CustomImageFetcher } from '../types/custom-image-fetcher.js'
+
 /**
  * Stores the current custom fetcher function if registered by the user.
  */
-let customImageFetcher: ((id: string) => Promise<Uint8Array>) | undefined
+let customImageFetcher: CustomImageFetcher | undefined
 
 /**
  * Registers a custom fetcher function for image retrieval.
  * When set, this function will be used instead of the default fetcher.
  */
 export const registerCustomImageFetcher = (
-  fetcher: (id: string) => Promise<Uint8Array>,
+  fetcher: CustomImageFetcher | undefined,
 ) => {
   customImageFetcher = fetcher
 }

--- a/src/frontend/image-fetcher.ts
+++ b/src/frontend/image-fetcher.ts
@@ -6,12 +6,15 @@ import { getDefaultImageFetcher } from './default-image-fetcher.js'
  * (if registered) or the default Pixstore fetcher.
  * Always returns the wire-format Uint8Array for the given image id.
  */
-export const fetchEncodedImage = async (id: string): Promise<Uint8Array> => {
+export const fetchEncodedImage = async (
+  id: string,
+  context?: any,
+): Promise<Uint8Array> => {
   const customImageFetcher = getCustomImageFetcher()
 
-  const imageFetcher = customImageFetcher
-    ? customImageFetcher
-    : getDefaultImageFetcher()
-
-  return imageFetcher(id)
+  if (customImageFetcher) {
+    return customImageFetcher(id, context)
+  }
+  const defaultImageFetcher = getDefaultImageFetcher()
+  return defaultImageFetcher(id)
 }

--- a/src/frontend/image-service.ts
+++ b/src/frontend/image-service.ts
@@ -11,7 +11,10 @@ import type { ImageRecord } from '../types/image-record.js'
  * Retrieves image data using token-based cache validation.
  * Returns the cached Blob if token matches; otherwise fetches, updates, and returns new Blob.
  */
-export const getImage = async (record: ImageRecord): Promise<Blob> => {
+export const getImage = async (
+  record: ImageRecord,
+  context?: any,
+): Promise<Blob> => {
   // Attempt to read the cached image from IndexedDB by ID
   const cached = await readImageRecord(record.id)
 
@@ -20,8 +23,10 @@ export const getImage = async (record: ImageRecord): Promise<Blob> => {
     return cached.data
   }
 
+  console.log('FROM-API-context: ', context)
+
   // Otherwise, fetch the latest encoded image from the backend
-  const encoded = await fetchEncodedImage(record.id)
+  const encoded = await fetchEncodedImage(record.id, context)
 
   // Decode and convert the encoded payload into a usable image record
   const formatted = formatEncodedImage(record.id, encoded)

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -1,6 +1,7 @@
 import type { PixstoreFrontendConfig } from '../types/pixstore-config.js'
 import { initPixstore } from '../shared/pixstore-config.js'
 import { registerCustomImageFetcher } from './custom-image-fetcher.js'
+import type { CustomImageFetcher } from '../types/custom-image-fetcher.js'
 
 /**
  * Initializes the Pixstore frontend module with the given configuration.
@@ -8,12 +9,10 @@ import { registerCustomImageFetcher } from './custom-image-fetcher.js'
  */
 export const initPixstoreFrontend = (
   config: Partial<PixstoreFrontendConfig> = {},
-  customImageFetcher?: (id: string) => Promise<Uint8Array>,
+  customImageFetcher?: CustomImageFetcher,
 ) => {
   initPixstore(config)
-  if (customImageFetcher) {
-    registerCustomImageFetcher(customImageFetcher)
-  }
+  registerCustomImageFetcher(customImageFetcher)
 }
 // Export main image service functions for external use
 export { getImage, getCachedImage, deleteCachedImage } from './image-service.js'

--- a/src/types/custom-image-fetcher.ts
+++ b/src/types/custom-image-fetcher.ts
@@ -1,0 +1,4 @@
+export type CustomImageFetcher = (
+  id: string,
+  context?: any,
+) => Promise<Uint8Array>


### PR DESCRIPTION
- Adds an optional `context` parameter to the custom image fetcher interface
- Enables advanced usage such as multi-param endpoints (e.g. both playerId and imageId), custom headers, or dynamic fetching logic
- Fully backward compatible

Closes #48