### PR TITLE
fix: fix frontend config type

### DIFF
--- a/src/backend/default-endpoint.ts
+++ b/src/backend/default-endpoint.ts
@@ -83,8 +83,8 @@ const requestHandler = (
  * - Uses `unref()` so Jest or other processes can exit cleanly.
  */
 export const startDefaultEndpoint = (): void => {
-  const DEFAULT_ENDPOINT_HOST = pixstoreConfig.defaultEndpointHost
-  const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointPort
+  const DEFAULT_ENDPOINT_HOST = pixstoreConfig.defaultEndpointListenHost
+  const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointListenPort
 
   if (server) return
 

--- a/src/frontend/default-image-fetcher.ts
+++ b/src/frontend/default-image-fetcher.ts
@@ -7,9 +7,9 @@ import { pixstoreConfig } from '../shared/pixstore-config.js'
  * the wire format protocol: [1 byte format][8 byte token][N bytes buffer].
  */
 const defaultImageFetcher = async (id: string): Promise<Uint8Array> => {
-  const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointPort
+  const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointConnectPort
   const DEFAULT_ENDPOINT_ROUTE = pixstoreConfig.defaultEndpointRoute
-  const SERVER_HOST = pixstoreConfig.defaultEndpointHost
+  const SERVER_HOST = pixstoreConfig.defaultEndpointConnectHost
   // Construct the full URL using constants
   const url = `http://${SERVER_HOST}:${DEFAULT_ENDPOINT_PORT}${DEFAULT_ENDPOINT_ROUTE}/${encodeURIComponent(id)}`
 

--- a/src/shared/pixstore-config.ts
+++ b/src/shared/pixstore-config.ts
@@ -75,7 +75,7 @@ export const defaultConfig: PixstoreConfig = {
     : 3001,
   defaultEndpointRoute: '/pixstore-image',
 
-  backendApiHost: IS_TEST ? '127.0.0.1' : 'unknown',
+  defaultEndpointHost: IS_TEST ? '127.0.0.1' : 'unknown',
   frontendDbName: IS_TEST ? 'pixstore-test' : 'pixstore',
   frontendDbVersion: 1,
   imageStoreName: 'images',

--- a/src/shared/pixstore-config.ts
+++ b/src/shared/pixstore-config.ts
@@ -46,16 +46,21 @@ const validateConfig = (config: Partial<PixstoreConfig>): void => {
     throw new Error('imageStoreName cannot be empty')
   }
 
-  // port must be in valid range
-  if (config.defaultEndpointPort !== undefined) {
-    const port = config.defaultEndpointPort
-    if (!Number.isInteger(port) || port < 1 || port > 65535) {
-      throw new Error(
-        'defaultEndpointPort must be an integer between 1 and 65535',
-      )
+  // ports must be in valid range
+  const validatePort = (name: string, port: number | undefined) => {
+    if (
+      port !== undefined &&
+      (!Number.isInteger(port) || port < 1 || port > 65535)
+    ) {
+      throw new Error(`${name} must be an integer between 1 and 65535`)
     }
   }
+
+  validatePort('defaultEndpointListenPort', config.defaultEndpointListenPort)
+  validatePort('defaultEndpointConnectPort', config.defaultEndpointConnectPort)
 }
+
+const DEFAULT_ENDPOINT_TEST_PORT = 10000 + Math.floor(Math.random() * 50000)
 
 /**
  * The default Pixstore configuration object.
@@ -66,16 +71,14 @@ export const defaultConfig: PixstoreConfig = {
   ...buildFormatMaps(DEFAULT_IMAGE_FORMATS),
   imageExtension: '.pixstore-image',
   imageRootDir: IS_TEST ? 'pixstore-test-images' : 'pixstore-images',
-
   databasePath: IS_TEST ? './.pixstore-test.sqlite' : './.pixstore.sqlite',
-  defaultEndpointHost: IS_TEST ? '127.0.0.1' : '0.0.0.0',
   defaultEndpointEnabled: true,
-  defaultEndpointPort: IS_TEST
-    ? 10000 + Math.floor(Math.random() * 50000)
-    : 3001,
   defaultEndpointRoute: '/pixstore-image',
+  defaultEndpointListenHost: IS_TEST ? '127.0.0.1' : '0.0.0.0',
+  defaultEndpointListenPort: IS_TEST ? DEFAULT_ENDPOINT_TEST_PORT : 3001,
 
-  defaultEndpointHost: IS_TEST ? '127.0.0.1' : 'unknown',
+  defaultEndpointConnectHost: IS_TEST ? '127.0.0.1' : 'unknown',
+  defaultEndpointConnectPort: IS_TEST ? DEFAULT_ENDPOINT_TEST_PORT : 3001,
   frontendDbName: IS_TEST ? 'pixstore-test' : 'pixstore',
   frontendDbVersion: 1,
   imageStoreName: 'images',

--- a/src/types/pixstore-config.ts
+++ b/src/types/pixstore-config.ts
@@ -13,13 +13,14 @@ export interface PixstoreBackendConfig {
 
 export interface PixstoreFrontendConfig {
   imageFormats: readonly ImageFormat[]
-  backendApiHost: string
   frontendDbName: string
   frontendDbVersion: number
   imageStoreName: string
   frontendImageCacheLimit: number
   frontendCleanupBatch: number
+  defaultEndpointHost: string
   defaultEndpointPort: number
+  defaultEndpointRoute: string
 }
 
 export interface PixstoreConfig

--- a/src/types/pixstore-config.ts
+++ b/src/types/pixstore-config.ts
@@ -4,9 +4,9 @@ export interface PixstoreBackendConfig {
   imageFormats: readonly ImageFormat[]
   imageRootDir: string
   databasePath: string
-  defaultEndpointHost: string
   defaultEndpointEnabled: boolean
-  defaultEndpointPort: number
+  defaultEndpointListenHost: string
+  defaultEndpointListenPort: number
   defaultEndpointRoute: string
   accessControlAllowOrigin: string
 }
@@ -18,8 +18,8 @@ export interface PixstoreFrontendConfig {
   imageStoreName: string
   frontendImageCacheLimit: number
   frontendCleanupBatch: number
-  defaultEndpointHost: string
-  defaultEndpointPort: number
+  defaultEndpointConnectHost: string
+  defaultEndpointConnectPort: number
   defaultEndpointRoute: string
 }
 

--- a/tests/modules/backend/default-endpoint.test.ts
+++ b/tests/modules/backend/default-endpoint.test.ts
@@ -14,9 +14,9 @@ import {
 
 import { pixstoreConfig } from '../../../src/shared/pixstore-config.js'
 import { initializeDatabase } from '../../../src/backend/database.js'
-const DEFAULT_ENDPOINT_HOST = pixstoreConfig.defaultEndpointHost
+const DEFAULT_ENDPOINT_HOST = pixstoreConfig.defaultEndpointConnectHost
 const DEFAULT_ENDPOINT_ROUTE = pixstoreConfig.defaultEndpointRoute
-const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointPort
+const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointConnectPort
 
 beforeAll(() => {
   initializeDatabase()

--- a/tests/modules/shared/pixstore-config.test.ts
+++ b/tests/modules/shared/pixstore-config.test.ts
@@ -57,12 +57,21 @@ describe('Pixstore config system', () => {
     )
   })
 
-  it('throws if defaultEndpointPort out of range', () => {
-    expect(() => initPixstore({ defaultEndpointPort: 0 })).toThrow(
-      'defaultEndpointPort must be an integer between 1 and 65535',
+  it('throws if defaultEndpointListenPort out of range', () => {
+    expect(() => initPixstore({ defaultEndpointListenPort: 0 })).toThrow(
+      'defaultEndpointListenPort must be an integer between 1 and 65535',
     )
-    expect(() => initPixstore({ defaultEndpointPort: 70000 })).toThrow(
-      'defaultEndpointPort must be an integer between 1 and 65535',
+    expect(() => initPixstore({ defaultEndpointListenPort: 70000 })).toThrow(
+      'defaultEndpointListenPort must be an integer between 1 and 65535',
+    )
+  })
+
+  it('throws if defaultEndpointConnectPort out of range', () => {
+    expect(() => initPixstore({ defaultEndpointConnectPort: 0 })).toThrow(
+      'defaultEndpointConnectPort must be an integer between 1 and 65535',
+    )
+    expect(() => initPixstore({ defaultEndpointConnectPort: 70000 })).toThrow(
+      'defaultEndpointConnectPort must be an integer between 1 and 65535',
     )
   })
 })


### PR DESCRIPTION
- Added defaultEndpointRoute to PixstoreFrontendConfig for route awareness
- Renamed backendApiHost → defaultEndpointHost for consistency with backend config