### PR TITLE
fix: remove unnecessary `dir` param from updateImageFromFile

### DIFF
--- a/src/backend/image-service.ts
+++ b/src/backend/image-service.ts
@@ -48,11 +48,17 @@ const writeImage = async (
   buffer: Buffer,
   dir?: string,
 ): Promise<ImageRecord> => {
+  // Encrypt the buffer using AES-GCM and get encryption metadata
   const { encrypted, meta } = encryptImage(buffer)
+
+  // Save the encrypted image buffer to disk
   await saveImageFile(id, encrypted)
+
   try {
+    // Write image metadata (token, key, iv, tag) to the database
     return writeImageRecord(id, meta)
   } catch (err) {
+    // If writing metadata fails, delete the saved image to avoid inconsistency
     deleteImageFile(id)
     throw err
   }
@@ -66,62 +72,74 @@ export const saveImage = async (
   buffer: Buffer,
   dir?: string,
 ): Promise<ImageRecord> => {
+  // Generate a unique ID for this image, optionally scoped by dir
   const id = createUniqueId(dir)
+
+  // Write the encrypted image and metadata
   return await writeImage(id, buffer, dir)
 }
 
 /**
- * Reads an image file from disk and saves it as a new image.
- * This is a convenience wrapper around saveImage().
+ * Reads an image file from disk and saves it as a new image
+ * This is a convenience wrapper around saveImage()
  */
 export const saveImageFromFile = async (
   filePath: string,
   dir?: string,
 ): Promise<ImageRecord> => {
+  // Read file content into a Buffer
   const buffer = await diskToBuffer(filePath)
+
+  // Save buffer as encrypted image
   return await saveImage(buffer, dir)
 }
 
 /**
- * Updates an existing image by overwriting the file and refreshing the database record.
- * Optionally, a directory prefix can be specified.
+ * Updates an existing image by overwriting the file and refreshing the database record
+ * Optionally, a directory prefix can be specified
  */
 export const updateImage = async (
   id: string,
   buffer: Buffer,
-  dir?: string,
 ): Promise<ImageRecord> => {
+  // Check if image exists in the database
   if (!imageRecordExists(id)) {
     throw new Error(`Image not found: ${id}`)
   }
-  return await writeImage(id, buffer, dir)
+
+  // Overwrite image and update its metadata
+  return await writeImage(id, buffer)
 }
 
 /**
- * Reads a buffer from a file and updates the image with the given ID.
- * Optionally, a directory prefix can be specified.
+ * Reads a buffer from a file and updates the image with the given ID
+ * Optionally, a directory prefix can be specified
  */
 export const updateImageFromFile = async (
   id: string,
   filePath: string,
-  dir?: string,
 ): Promise<ImageRecord> => {
+  // Read file content into a Buffer
   const buffer = await diskToBuffer(filePath)
-  return await updateImage(id, buffer, dir)
+
+  // Overwrite existing image with new buffer
+  return await updateImage(id, buffer)
 }
 
 /**
- * Deletes the image file and corresponding database record for the given ID.
- * Returns true if at least one of them was deleted.
+ * Deletes the image file and corresponding database record for the given ID
+ * Returns true if at least one of them was deleted
  */
 export const deleteImage = async (id: string): Promise<boolean> => {
   let deleted = false
 
+  // Delete the image file if it exists
   if (await imageFileExists(id)) {
     await deleteImageFile(id)
     deleted = true
   }
 
+  // Delete the metadata record if it exists
   if (imageRecordExists(id)) {
     deleteImageRecord(id)
     deleted = true
@@ -131,16 +149,18 @@ export const deleteImage = async (id: string): Promise<boolean> => {
 }
 
 /**
- * Returns the image record (id + token) from the database.
- * Returns null if not found.
+ * Returns the image record (id + token) from the database
+ * Returns null if not found
  */
 export const getImageRecord = (id: string): ImageRecord | null => {
+  // Reads imageRecord from database (includes id, token, and meta fields)
   return readImageRecord(id)
 }
 
 /**
- * Checks whether the image exists either on disk or in the database.
+ * Checks whether the image exists either on disk or in the database
  */
 export const imageExists = async (id: string): Promise<boolean> => {
+  // Returns true if image file or metadata record exists
   return (await imageFileExists(id)) || imageRecordExists(id)
 }

--- a/tests/modules/backend/default-endpoint.test.ts
+++ b/tests/modules/backend/default-endpoint.test.ts
@@ -59,7 +59,7 @@ describe('Pixstore default endpoint – single file update flow', () => {
     expect(meta1).toBeDefined()
 
     // Update with new image
-    const record2 = await updateImage(imageId, buffer2, 'students')
+    const record2 = await updateImage(imageId, buffer2)
     expect(record2.token).not.toBe(originalToken)
 
     // Fetch updated via endpoint

--- a/tests/modules/backend/image-service.test.ts
+++ b/tests/modules/backend/image-service.test.ts
@@ -70,11 +70,7 @@ describe('updateImageFromFile', () => {
 
     await sleep(5)
 
-    const updated = await updateImageFromFile(
-      original.id,
-      originalPath,
-      testDir,
-    )
+    const updated = await updateImageFromFile(original.id, originalPath)
 
     expect(updated.id).toBe(original.id)
     expect(updated.token).not.toBe(original.token)
@@ -87,9 +83,7 @@ describe('updateImageFromFile', () => {
   it('should reject when updating a non-existent image', async () => {
     const fakeId = `${testDir}:no-such-id`
     const filePath = path.join(assetsDir, '1-pixel.png')
-    await expect(
-      updateImageFromFile(fakeId, filePath, testDir),
-    ).rejects.toThrow()
+    await expect(updateImageFromFile(fakeId, filePath)).rejects.toThrow()
   })
 })
 

--- a/tests/scenario/backend-image-highload.test.ts
+++ b/tests/scenario/backend-image-highload.test.ts
@@ -41,7 +41,7 @@ describe('Pixstore backend highload scenario', () => {
   it('should update all images', async () => {
     const buffer2 = fs.readFileSync(imageFile2)
     for (const id of ids) {
-      await updateImage(id, buffer2, prefix)
+      await updateImage(id, buffer2)
       const { encrypted } = await getWirePayload(id)
       expect(encrypted.length).toBeGreaterThan(0)
     }


### PR DESCRIPTION
- updateImageFromFile() no longer accepts a `dir` argument
- Directory is implied by the image ID and should not be redefined