### PR TITLE
docs: complete Pixstore API reference for backend, frontend, and shared types

### DIFF
--- a/docusaurus/docs/reference/_category_.json
+++ b/docusaurus/docs/reference/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "API Reference",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "description": "Reference for all Pixstore public APIs, including backend and frontend modules."
+  }
+}

--- a/docusaurus/docs/reference/backend/_category_.json
+++ b/docusaurus/docs/reference/backend/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Backend Module",
+  "position": 1,
+  "link": {
+    "type": "generated-index",
+    "description": "API reference for the Pixstore backend module. Includes initialization, image storage, and custom endpoint helpers."
+  }
+}

--- a/docusaurus/docs/reference/backend/custom-endpoint.md
+++ b/docusaurus/docs/reference/backend/custom-endpoint.md
@@ -1,0 +1,84 @@
+---
+id: custom-endpoint
+title: Custom Endpoint Helper
+sidebar_position: 3
+---
+
+The function on this page is exported from the `pixstore/backend` entrypoint:
+
+```ts
+import { customEndpointHelper } from 'pixstore/backend'
+```
+
+## `customEndpointHelper`
+
+This function allows you to build your own custom image-serving endpoint for Pixstore.
+
+It returns an image payload encoded in Pixstore's wire format (`Uint8Array`), which is directly consumable by the frontend.
+
+If the default endpoint is enabled, this function throws an error to prevent accidental dual-endpoint usage.
+
+---
+
+### Description
+
+```ts
+export const customEndpointHelper = (
+  id: string
+): Promise<Uint8Array>
+```
+
+---
+
+### Parameters
+
+| Name | Type     | Description                              |
+| ---- | -------- | ---------------------------------------- |
+| `id` | `string` | The ID of the image to retrieve and send |
+
+---
+
+### Example
+
+```ts
+try {
+  // Get encrypted wire-format image buffer
+  const payload = await customEndpointHelper(imageId)
+
+  // Return to client as binary
+  res.send(payload)
+} catch {
+  // Handle missing image or endpoint conflict
+  res.status(404).json({ error: 'Image not found' })
+}
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Returns a Pixstore wire format encoded image payload (Uint8Array) for the given image id.
+ * Throws if the default endpoint is running, to prevent accidental double endpoint use.
+ * Can be used in any custom endpoint handler to build a response.
+ */
+export const customEndpointHelper = async (id: string): Promise<Uint8Array> => {
+  // Prevent usage if the default endpoint is active (safety guard)
+  if (isServerStarted()) {
+    throw new Error(
+      'Pixstore custom endpoint mode is not active. Please disable the default endpoint before using customEndpointHelper().',
+    )
+  }
+
+  // Fetch decrypted image and metadata as a wire payload structure
+  const wirePayload = await getWirePayload(id)
+
+  // Encode it as Uint8Array in Pixstore wire format (used by frontend to decode)
+  return encodeWirePayload(wirePayload)
+}
+```
+
+---
+
+📄 Source: [`src/backend/custom-endpoint.ts`](https://github.com/sDenizOzturk/pixstore/blob/main/src/backend/custom-endpoint.ts)

--- a/docusaurus/docs/reference/backend/image-service.md
+++ b/docusaurus/docs/reference/backend/image-service.md
@@ -1,0 +1,499 @@
+---
+id: image-service
+title: Image Service
+sidebar_position: 2
+---
+
+# Image Service
+
+This module provides high-level functions to store, retrieve, update, and delete encrypted images on the backend.
+
+It operates on binary buffers, handles AES-GCM encryption internally, and manages image metadata via SQLite.
+
+All functions are exported from the `pixstore/backend` entrypoint:
+
+```ts
+import {
+  getImageRecord,
+  saveImage,
+  saveImageFromFile,
+  updateImage,
+  updateImageFromFile,
+  deleteImage,
+  imageExists,
+} from 'pixstore/backend'
+```
+
+Each function is described in detail below.
+
+## `getImageRecord`
+
+Retrieves the metadata for an image previously saved to the backend.
+
+Returns an `ImageRecord` object containing the image's `id`, `token`, and `imageFormat`, or `null` if the image does not exist in the database.
+
+---
+
+### Description
+
+```ts
+export const getImageRecord = (id: string): ImageRecord | null
+```
+
+---
+
+### Parameters
+
+| Name | Type     | Description                 |
+| ---- | -------- | --------------------------- |
+| `id` | `string` | The unique ID of the image. |
+
+---
+
+### Example
+
+```ts
+const imageRecord = getImageRecord(imageId)!
+
+// Send this to the frontend.
+// The Pixstore frontend needs imageRecord to fetch and decrypt the actual image.
+const player: BasketballPlayer = {
+  ...playerRecord,
+  imageRecord,
+}
+
+res.json(player)
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Returns the image record (id + token) from the database.
+ * Returns null if not found.
+ */
+export const getImageRecord = (id: string): ImageRecord | null => {
+  // Reads imageRecord from database (includes id, token, and meta fields)
+  return readImageRecord(id)
+}
+```
+
+---
+
+## `saveImage`
+
+Creates and saves a new image using an in-memory `Buffer`.  
+The image is encrypted using AES-GCM, written to disk, and registered in the metadata database.
+
+This function generates a unique `id` for the image, optionally namespaced by a `dir`.
+
+---
+
+### Description
+
+```ts
+export const saveImage = (
+  buffer: Buffer,
+  dir?: string
+): Promise<ImageRecord>
+```
+
+---
+
+### Parameters
+
+| Name     | Type      | Description                                                     |
+| -------- | --------- | --------------------------------------------------------------- |
+| `buffer` | `Buffer`  | Raw binary data of the image. Will be encrypted before storage. |
+| `dir`    | `string?` | Optional namespace or folder scope for the image ID.            |
+
+---
+
+### Example
+
+```ts
+const imageRecord = await saveImage(imageBuffer, 'players')
+
+// Send this to the frontend.
+// The Pixstore frontend needs imageRecord to fetch and decrypt the actual image.
+const player: BasketballPlayer = {
+  ...playerRecord,
+  imageRecord,
+}
+
+res.json(player)
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Saves an image buffer to disk and creates a corresponding database record.
+ * If writing to the database fails, the saved file is deleted to maintain consistency.
+ */
+export const saveImage = async (
+  buffer: Buffer,
+  dir?: string,
+): Promise<ImageRecord> => {
+  // Generate a unique ID for this image, optionally scoped by dir
+  const id = createUniqueId(dir)
+
+  // Write the encrypted image and metadata
+  return await writeImage(id, buffer, dir)
+}
+
+/**
+ * Writes an image buffer to disk and updates or creates its database record.
+ * If writing to the database fails, the file is deleted to maintain consistency.
+ */
+const writeImage = async (
+  id: string,
+  buffer: Buffer,
+  dir?: string,
+): Promise<ImageRecord> => {
+  // Encrypt the buffer using AES-GCM and get encryption metadata
+  const { encrypted, meta } = encryptImage(buffer)
+
+  // Save the encrypted image buffer to disk
+  await saveImageFile(id, encrypted)
+
+  try {
+    // Write image metadata (token, key, iv, tag) to the database
+    return writeImageRecord(id, meta)
+  } catch (err) {
+    // If writing metadata fails, delete the saved image to avoid inconsistency
+    deleteImageFile(id)
+    throw err
+  }
+}
+```
+
+---
+
+## `saveImageFromFile`
+
+Reads an image file from disk and saves it as a new encrypted image.
+
+This is a convenience wrapper around `saveImage()`. It lets you work directly with file paths instead of manually reading buffers.
+
+---
+
+### Description
+
+```ts
+export const saveImageFromFile = (
+  filePath: string,
+  dir?: string
+): Promise<ImageRecord>
+```
+
+---
+
+### Parameters
+
+| Name       | Type      | Description                                                   |
+| ---------- | --------- | ------------------------------------------------------------- |
+| `filePath` | `string`  | Path to the image file on disk                                |
+| `dir`      | `string?` | Optional namespace or folder scope for the generated image ID |
+
+---
+
+### Example
+
+```ts
+const imageRecord = await saveImageFromFile('./assets/logo.png', 'system')
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Reads an image file from disk and saves it as a new image
+ * This is a convenience wrapper around saveImage()
+ */
+export const saveImageFromFile = async (
+  filePath: string,
+  dir?: string,
+): Promise<ImageRecord> => {
+  // Read file content into a Buffer
+  const buffer = await diskToBuffer(filePath)
+
+  // Save buffer as encrypted image
+  return await saveImage(buffer, dir)
+}
+```
+
+---
+
+## `updateImage`
+
+Overwrites an existing image with new binary content and refreshes the corresponding metadata.
+
+This function expects the image ID to already exist in the database. If not, it throws an error.
+
+---
+
+### Description
+
+```ts
+export const updateImage = (
+  id: string,
+  buffer: Buffer,
+): Promise<ImageRecord>
+```
+
+---
+
+### Parameters
+
+| Name     | Type     | Description                                      |
+| -------- | -------- | ------------------------------------------------ |
+| `id`     | `string` | The ID of the image to update                    |
+| `buffer` | `Buffer` | New binary content to replace the existing image |
+
+---
+
+### Example
+
+```ts
+try {
+  const updatedImageRecord = await updateImage('player-123', newBuffer)
+  // Return the updated imageRecord to frontend for cache update
+} catch {
+  // Image not found!
+}
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Updates an existing image by overwriting the file and refreshing the database record
+ */
+export const updateImage = async (
+  id: string,
+  buffer: Buffer,
+): Promise<ImageRecord> => {
+  // Check if image exists in the database
+  if (!imageRecordExists(id)) {
+    throw new Error(`Image not found: ${id}`)
+  }
+
+  // Overwrite image and update its metadata
+  return await writeImage(id, buffer)
+}
+
+/**
+ * Writes an image buffer to disk and updates or creates its database record.
+ * If writing to the database fails, the file is deleted to maintain consistency.
+ */
+const writeImage = async (
+  id: string,
+  buffer: Buffer,
+  dir?: string,
+): Promise<ImageRecord> => {
+  // Encrypt the buffer using AES-GCM and get encryption metadata
+  const { encrypted, meta } = encryptImage(buffer)
+
+  // Save the encrypted image buffer to disk
+  await saveImageFile(id, encrypted)
+
+  try {
+    // Write image metadata (token, key, iv, tag) to the database
+    return writeImageRecord(id, meta)
+  } catch (err) {
+    // If writing metadata fails, delete the saved image to avoid inconsistency
+    deleteImageFile(id)
+    throw err
+  }
+}
+```
+
+---
+
+## `updateImageFromFile`
+
+Updates an existing image by reading new binary content from a file and replacing both the file and its metadata.
+
+This function requires the image `id` to already exist in the database.
+It is a convenience wrapper around `updateImage()` and lets you work directly with file paths.
+
+---
+
+### Description
+
+```ts
+export const updateImageFromFile = (
+  id: string,
+  filePath: string
+): Promise<ImageRecord>
+```
+
+---
+
+### Parameters
+
+| Name       | Type     | Description                        |
+| ---------- | -------- | ---------------------------------- |
+| `id`       | `string` | The ID of the image to update      |
+| `filePath` | `string` | Path to the new image file on disk |
+
+---
+
+### Example
+
+```ts
+await updateImageFromFile('player-123', './images/new-logo.png')
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Reads a buffer from a file and updates the image with the given ID.
+ */
+export const updateImageFromFile = async (
+  id: string,
+  filePath: string,
+): Promise<ImageRecord> => {
+  // Read file content into a Buffer
+  const buffer = await diskToBuffer(filePath)
+
+  // Overwrite existing image with new buffer
+  return await updateImage(id, buffer)
+}
+```
+
+---
+
+## `deleteImage`
+
+Deletes both the encrypted image file and its metadata record for the specified image `id`.
+
+Returns `true` if at least one of them was successfully deleted.
+
+---
+
+### Description
+
+```ts
+export const deleteImage = (
+  id: string
+): Promise<boolean>
+```
+
+---
+
+### Parameters
+
+| Name | Type     | Description                 |
+| ---- | -------- | --------------------------- |
+| `id` | `string` | The unique ID of the image. |
+
+---
+
+### Example
+
+```ts
+const success = await deleteImage(imageId)
+
+if (success) {
+  console.log('Image deleted.')
+} else {
+  console.log('Image not found.')
+}
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Deletes the image file and corresponding database record for the given ID
+ * Returns true if at least one of them was deleted
+ */
+export const deleteImage = async (id: string): Promise<boolean> => {
+  let deleted = false
+
+  // Delete the image file if it exists
+  if (await imageFileExists(id)) {
+    await deleteImageFile(id)
+    deleted = true
+  }
+
+  // Delete the metadata record if it exists
+  if (imageRecordExists(id)) {
+    deleteImageRecord(id)
+    deleted = true
+  }
+
+  return deleted
+}
+```
+
+---
+
+## `imageExists`
+
+Checks whether the image with the given `id` exists on disk or in the metadata database.
+
+This can be used to verify if an image is still present in storage. Useful for debugging, logging, or conditional logic.
+
+---
+
+### Description
+
+```ts
+export const imageExists = (
+  id: string
+): Promise<boolean>
+```
+
+---
+
+### Parameters
+
+| Name | Type     | Description                 |
+| ---- | -------- | --------------------------- |
+| `id` | `string` | The unique ID of the image. |
+
+---
+
+### Example
+
+```ts
+if (await imageExists(imageId)) {
+  console.log('Image is available')
+} else {
+  console.log('Image not found')
+}
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Checks whether the image exists either on disk or in the database
+ */
+export const imageExists = async (id: string): Promise<boolean> => {
+  // Returns true if image file or metadata record exists
+  return (await imageFileExists(id)) || imageRecordExists(id)
+}
+```
+
+---
+
+📄 Source: [`src/backend/image-service.ts`](https://github.com/sDenizOzturk/pixstore/blob/main/src/backend/image-service.ts)

--- a/docusaurus/docs/reference/backend/init.md
+++ b/docusaurus/docs/reference/backend/init.md
@@ -1,0 +1,104 @@
+---
+id: initialization
+title: Initialization
+sidebar_position: 1
+---
+
+The function on this page is exported from the `pixstore/backend` entrypoint:
+
+```ts
+import { initPixstoreBackend } from 'pixstore/backend'
+```
+
+## `initPixstoreBackend`
+
+Initializes the Pixstore backend module with optional runtime configuration.
+
+This is the main entry point to set up Pixstore on the server side.
+
+It configures the internal state, prepares the metadata database, and optionally starts the default HTTP endpoint.
+
+---
+
+### Description
+
+```ts
+export const initPixstoreBackend = (
+  config: Partial<PixstoreBackendConfig> = {}
+): void
+```
+
+### Parameters
+
+| Name   | Type                             | Description                                     |
+| ------ | -------------------------------- | ----------------------------------------------- |
+| config | `Partial<PixstoreBackendConfig>` | Optional runtime configuration for the backend. |
+
+#### PixstoreBackendConfig
+
+The `PixstoreBackendConfig` object allows you to customize how Pixstore behaves in the backend environment.
+All fields are optional; missing values are filled using the internal `defaultConfig`.
+
+| Property                    | Type            | Default (non-test)        | Description                                                     |
+| --------------------------- | --------------- | ------------------------- | --------------------------------------------------------------- |
+| `imageFormats`              | `ImageFormat[]` | `['png', 'jpeg', 'webp']` | Allowed image formats                                           |
+| `imageRootDir`              | `string`        | `'pixstore-images'`       | Folder where images are saved                                   |
+| `databasePath`              | `string`        | `'./.pixstore.sqlite'`    | Path to SQLite metadata DB                                      |
+| `defaultEndpointEnabled`    | `boolean`       | `true`                    | Whether to expose the default GET image endpoint                |
+| `defaultEndpointRoute`      | `string`        | `'/pixstore-image'`       | Route path for the default image endpoint                       |
+| `defaultEndpointListenHost` | `string`        | `'0.0.0.0'`               | Host/IP where the image endpoint HTTP server listens            |
+| `defaultEndpointListenPort` | `number`        | `3001`                    | Port where the image endpoint HTTP server listens               |
+| `accessControlAllowOrigin`  | `string`        | `'*'`                     | CORS `Access-Control-Allow-Origin` header for the default route |
+
+> ℹ️ When running in test mode (`IS_TEST === true`), values like paths and ports are automatically randomized or sandboxed.
+
+---
+
+### Example
+
+```ts
+import { initPixstoreBackend } from 'pixstore/backend'
+
+initPixstoreBackend({
+  defaultEndpointEnabled: false,
+})
+```
+
+This will initialize the database and disable default image endpoint.
+
+:::caution
+If you disable the default endpoint just like this example
+you **must** implement your own image-serving endpoint using `customEndpointHelper`.
+
+Otherwise, the frontend mechanism of this library can not fetch images automatically
+:::
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Initializes the Pixstore backend module with the given configuration.
+ * Starts the default endpoint if enabled.
+ */
+export const initPixstoreBackend = (
+  config: Partial<PixstoreBackendConfig> = {},
+) => {
+  // Validates user config (e.g. cleanupBatch must be < cacheLimit)
+  // Then applies it to the internal Pixstore state
+  initPixstore(config)
+
+  // Prepares the database for storing image metadata
+  initializeDatabase()
+
+  // If enabled, starts the default image-serving HTTP endpoint
+  if (pixstoreConfig.defaultEndpointEnabled) {
+    startDefaultEndpoint()
+  }
+}
+```
+
+---
+
+📄 Source: [`src/backend/index.ts`](https://github.com/sDenizOzturk/pixstore/blob/main/src/backend/index.ts)

--- a/docusaurus/docs/reference/frontend/_category_.json
+++ b/docusaurus/docs/reference/frontend/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Frontend Module",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "description": "API reference for the Pixstore frontend module. Covers image retrieval, caching, and configuration."
+  }
+}

--- a/docusaurus/docs/reference/frontend/image-service.md
+++ b/docusaurus/docs/reference/frontend/image-service.md
@@ -1,0 +1,235 @@
+---
+id: image-service
+title: Image Service
+sidebar_position: 2
+---
+
+# Image Service
+
+This module provides high-level functions to retrieve and manage encrypted images on the frontend.
+
+It automatically fetches the image from the backend (using either the default endpoint or a custom fetcher), decrypts it using AES-GCM, and caches the result in IndexedDB for future access.
+
+All functions are exported from the `pixstore/frontend` entrypoint:
+
+```ts
+import {
+  getImage,
+  deleteCachedImage,
+  cachedImageExists,
+} from 'pixstore/frontend'
+```
+
+Each function is described in detail below.
+
+---
+
+## `getImage`
+
+Retrieves and decrypts an image using token-based cache validation.
+
+If the image is already cached in IndexedDB **and** the token matches, it is decrypted and returned directly.
+Otherwise, the image is fetched from the backend in encrypted wire format, decoded, cached, and then decrypted before returning as a `Blob`.
+
+---
+
+### Description
+
+```ts
+export const getImage = (
+  record: ImageRecord,
+  context?: any
+): Promise<Blob>
+```
+
+---
+
+### Parameters
+
+| Name      | Type          | Description                                                                |
+| --------- | ------------- | -------------------------------------------------------------------------- |
+| `record`  | `ImageRecord` | Metadata object received from backend (`id`, `token`, and `meta`)          |
+| `context` | `any?`        | Optional data passed to a custom image fetcher (if configured on frontend) |
+
+---
+
+### Example
+
+```ts
+try {
+  const blob = await getImage(imageRecord)
+  const url = URL.createObjectURL(blob)
+  // ...use in <img> or wherever
+} catch {
+  // show fallback, placeholder, etc.
+}
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Retrieves image data using token-based cache validation.
+ * Returns the cached Blob if token matches; otherwise fetches, updates, and returns new Blob.
+ */
+export const getImage = async (
+  record: ImageRecord,
+  context?: any,
+): Promise<Blob> => {
+  // Attempt to read the cached image from IndexedDB by ID
+  const { id, token, meta } = record
+  const cached = await readImageRecord(id)
+
+  // If a cached image exists and the token matches, return it immediately
+  if (cached && cached.token === token) {
+    const indexedDBRecord = await readImageRecord(id)
+    const encrypted = indexedDBRecord!.encrypted
+
+    // Decrypt the image using the extracted encrypted data and meta
+    const imagePayload = await decryptImage(encrypted, meta)
+
+    // Return the up-to-date Blob for rendering
+    return decryptedPayloadToBlob(imagePayload)
+  }
+
+  // Otherwise, fetch the latest encoded image from the backend
+  const encoded = await fetchEncodedImage(record.id, context)
+
+  // Decode the wire payload to extract encrypted data, meta, and token
+  const decodedWirePayload = decodeWirePayload(encoded)
+
+  // Prepare the IndexedDB record with fresh encrypted data and token
+  const indexedDBRecord: IndexedDBImageRecord = {
+    id,
+    encrypted: decodedWirePayload.encrypted,
+    token: decodedWirePayload.token,
+    lastUsed: Date.now(),
+  }
+
+  // Save the updated image into the local cache
+  await writeImageRecord(indexedDBRecord)
+
+  // Decrypt the image using the encrypted data and meta from the wire payload.
+  // The `record.meta` is not used, using stale meta could break decryption if the image was recently updated.
+  const imagePayload = await decryptImage(
+    decodedWirePayload.encrypted,
+    decodedWirePayload.meta,
+  )
+
+  // Return the up-to-date Blob for rendering
+  return decryptedPayloadToBlob(imagePayload)
+}
+```
+
+---
+
+## `deleteCachedImage`
+
+Removes an image from the local IndexedDB cache by its ID.
+Useful when you want to manually clear outdated or unused images from the frontend cache.
+
+---
+
+### Description
+
+```ts
+export const deleteCachedImage = (
+  id: string
+): Promise<void>
+```
+
+---
+
+### Parameters
+
+| Name | Type     | Description                       |
+| ---- | -------- | --------------------------------- |
+| `id` | `string` | ID of the cached image to delete. |
+
+---
+
+### Example
+
+```ts
+import { deleteCachedImage } from 'pixstore/frontend'
+
+await deleteCachedImage(imageId)
+
+// Optional: update UI or local state
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Removes a cached image from IndexedDB.
+ */
+export const deleteCachedImage = async (id: string): Promise<void> => {
+  // Deletes the image record (by ID) from the local IndexedDB cache
+  await deleteImageRecord(id)
+}
+```
+
+---
+
+## `cachedImageExists`
+
+Checks whether a cached image exists in the local IndexedDB by its ID.
+
+This can be used to conditionally load or invalidate image data before making a network request.
+
+---
+
+### Description
+
+```ts
+export const cachedImageExists = (
+  id: string
+): Promise<boolean>
+```
+
+---
+
+### Parameters
+
+| Name | Type     | Description                            |
+| ---- | -------- | -------------------------------------- |
+| `id` | `string` | ID of the image to check in the cache. |
+
+---
+
+### Example
+
+```ts
+import { cachedImageExists } from 'pixstore/frontend'
+
+const exists = await cachedImageExists(imageId)
+
+if (exists) {
+  console.log('Image is available locally.')
+} else {
+  console.log('Image needs to be fetched.')
+}
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Returns true if a cached image exists in IndexedDB for the given id.
+ */
+export const cachedImageExists = async (id: string): Promise<boolean> => {
+  // Checks IndexedDB for an image record with the specified ID
+  return await imageRecordExists(id)
+}
+```
+
+---
+
+📄 Source: [`src/frontend/image-service.ts`](https://github.com/sDenizOzturk/pixstore/blob/main/src/frontend/image-service.ts)

--- a/docusaurus/docs/reference/frontend/init.md
+++ b/docusaurus/docs/reference/frontend/init.md
@@ -1,0 +1,139 @@
+---
+id: initialization
+title: Initialization
+sidebar_position: 1
+---
+
+The function on this page is exported from the `pixstore/frontend` entrypoint:
+
+```ts
+import { initPixstoreFrontend } from 'pixstore/frontend'
+```
+
+## `initPixstoreFrontend`
+
+Initializes the Pixstore frontend module with optional configuration and an optional custom image fetcher.
+
+This is the main entry point to configure the frontend image cache, database name/version, and network behavior.
+
+---
+
+### Description
+
+```ts
+export const initPixstoreFrontend = (
+  config?: Partial<PixstoreFrontendConfig>,
+  customImageFetcher?: CustomImageFetcher
+): void
+```
+
+---
+
+### Parameters
+
+| Name                 | Type                              | Description                                             |
+| -------------------- | --------------------------------- | ------------------------------------------------------- |
+| `config`             | `Partial<PixstoreFrontendConfig>` | Optional overrides for internal frontend configuration. |
+| `customImageFetcher` | `CustomImageFetcher`              | Optional function to override how images are fetched.   |
+
+---
+
+### PixstoreFrontendConfig
+
+The `PixstoreFrontendConfig` object lets you customize the image caching behavior and database names.
+
+All fields are optional; if not provided, Pixstore uses defaults from its internal `defaultConfig`.
+
+| Property                     | Type     | Default (non-test)  | Description                                                                |
+| ---------------------------- | -------- | ------------------- | -------------------------------------------------------------------------- |
+| `frontendDbName`             | `string` | `'pixstore'`        | IndexedDB database name                                                    |
+| `frontendDbVersion`          | `number` | `1`                 | IndexedDB schema version                                                   |
+| `imageStoreName`             | `string` | `'images'`          | Object store name for image records                                        |
+| `frontendImageCacheLimit`    | `number` | `1000`              | Maximum number of images to keep in the local cache                        |
+| `frontendCleanupBatch`       | `number` | `50`                | Number of items to remove per cleanup cycle when limit is exceeded         |
+| `defaultEndpointConnectHost` | `string` | `'unknown'`         | Host to contact for image fetching (used if no custom fetcher is provided) |
+| `defaultEndpointConnectPort` | `number` | `3001`              | Port to contact for image fetching                                         |
+| `defaultEndpointRoute`       | `string` | `'/pixstore-image'` | Route to contact for image fetching                                        |
+
+---
+
+> ℹ️ In test mode (`IS_TEST === true`), database names and limits are automatically sandboxed.
+
+---
+
+### CustomImageFetcher
+
+The optional `customImageFetcher` parameter allows you to override how images are fetched in the frontend.
+
+By default, Pixstore sends a `GET` request to the configured default endpoint (`defaultEndpointConnectHost`, `Port`, and `Route`).
+
+If you want to implement a custom download mechanism (e.g. with tokens, cookies, or alternative URLs), you can provide your own function:
+
+```ts
+type CustomImageFetcher = (id: string) => Promise<Uint8Array>
+```
+
+This function will be used by Pixstore internally instead of the default fetcher.
+
+:::caution
+If you provide a `customImageFetcher`, you must also implement a custom backend endpoint using `customEndpointHelper`.
+
+Otherwise, the default image-fetching logic is bypassed and Pixstore cannot retrieve images through the default route, even if it is enabled.
+:::
+
+---
+
+### Example
+
+```ts
+// Define a custom image fetcher function
+const customImageFetcher = async (id: string) => {
+  // Add custom authorization header
+  const jwt = getJwtFromYourAuthSystem()
+
+  // Construct your own image endpoint URL
+  const res = await fetch(`https://your-api.com/your-route/${id}`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  })
+
+  // Convert response to Uint8Array if successful
+  if (!res.ok) throw new Error('Failed to fetch image')
+  const arrayBuffer = await res.arrayBuffer()
+  return new Uint8Array(arrayBuffer)
+}
+
+// Initialize Pixstore frontend with custom fetcher and optional config overrides
+initPixstoreFrontend(
+  {
+    frontendImageCacheLimit: 2000,
+    frontendCleanupBatch: 100,
+  },
+  customImageFetcher,
+)
+```
+
+---
+
+### How it works?
+
+```ts
+/**
+ * Initializes the Pixstore frontend module with the given configuration.
+ * Optionally, a custom image fetcher function can be provided.
+ */
+export const initPixstoreFrontend = (
+  config: Partial<PixstoreFrontendConfig> = {},
+  customImageFetcher?: CustomImageFetcher,
+) => {
+  // Validates user config (e.g. cleanupBatch must be < cacheLimit)
+  // Then applies it to the internal Pixstore state
+  initPixstore(config)
+
+  // Register optional image fetcher override
+  registerCustomImageFetcher(customImageFetcher)
+}
+```
+
+---
+
+📄 Source: [`src/frontend/index.ts`](https://github.com/sDenizOzturk/pixstore/blob/main/src/frontend/index.ts)

--- a/docusaurus/docs/reference/types.md
+++ b/docusaurus/docs/reference/types.md
@@ -1,0 +1,65 @@
+---
+id: types
+title: Shared Types
+sidebar_position: 3
+---
+
+# Shared Types
+
+This page documents the shared type definitions used across Pixstore frontend and backend.
+
+All types on this page are exported from the main `pixstore` entrypoint:
+
+```ts
+import type { ImageRecord } from 'pixstore'
+```
+
+---
+
+## `ImageRecord`
+
+Represents a reference to an image stored in Pixstore, including the ID, access token, and decryption metadata.
+
+Used to fetch and decrypt images on the frontend.
+
+### Definition
+
+```ts
+export interface ImageRecord {
+  id: string
+  token: number
+  meta: ImageDecryptionMeta
+}
+```
+
+### Fields
+
+| Name    | Type                  | Description                                     |
+| ------- | --------------------- | ----------------------------------------------- |
+| `id`    | `string`              | Unique identifier of the image                  |
+| `token` | `number`              | Used for cache validation and versioning        |
+| `meta`  | `ImageDecryptionMeta` | Decryption metadata: key, IV, tag, format, etc. |
+
+---
+
+### How it works?
+
+```ts
+// Metadata required to decrypt an encrypted image
+export interface ImageDecryptionMeta {
+  key: string // Base64-encoded AES-GCM encryption key
+  iv: string // Initialization vector (IV) for AES-GCM, base64-encoded
+  tag: string // Authentication tag for AES-GCM, base64-encoded
+}
+
+// Reference object representing an image in Pixstore
+export interface ImageRecord {
+  id: string // Unique ID used to locate and identify the image
+  token: number // Used for cache validation and version control
+  meta: ImageDecryptionMeta // Metadata required to decrypt the image
+}
+```
+
+---
+
+📄 Source: [`src/types/image-record.ts`](https://github.com/sDenizOzturk/pixstore/blob/main/src/types/image-record.ts)

--- a/src/backend/custom-endpoint.ts
+++ b/src/backend/custom-endpoint.ts
@@ -8,11 +8,16 @@ import { isServerStarted } from './default-endpoint.js'
  * Can be used in any custom endpoint handler to build a response.
  */
 export const customEndpointHelper = async (id: string): Promise<Uint8Array> => {
+  // Prevent usage if the default endpoint is active (safety guard)
   if (isServerStarted()) {
     throw new Error(
       'Pixstore custom endpoint mode is not active. Please disable the default endpoint before using customEndpointHelper().',
     )
   }
+
+  // Fetch decrypted image and metadata as a wire payload structure
   const wirePayload = await getWirePayload(id)
+
+  // Encode it as Uint8Array in Pixstore wire format (used by frontend to decode)
   return encodeWirePayload(wirePayload)
 }

--- a/src/backend/image-service.ts
+++ b/src/backend/image-service.ts
@@ -40,6 +40,15 @@ export const getWirePayload = async (
 }
 
 /**
+ * Returns the image record (id + token) from the database
+ * Returns null if not found
+ */
+export const getImageRecord = (id: string): ImageRecord | null => {
+  // Reads imageRecord from database (includes id, token, and meta fields)
+  return readImageRecord(id)
+}
+
+/**
  * Writes an image buffer to disk and updates or creates its database record.
  * If writing to the database fails, the file is deleted to maintain consistency.
  */
@@ -96,7 +105,6 @@ export const saveImageFromFile = async (
 
 /**
  * Updates an existing image by overwriting the file and refreshing the database record
- * Optionally, a directory prefix can be specified
  */
 export const updateImage = async (
   id: string,
@@ -146,15 +154,6 @@ export const deleteImage = async (id: string): Promise<boolean> => {
   }
 
   return deleted
-}
-
-/**
- * Returns the image record (id + token) from the database
- * Returns null if not found
- */
-export const getImageRecord = (id: string): ImageRecord | null => {
-  // Reads imageRecord from database (includes id, token, and meta fields)
-  return readImageRecord(id)
 }
 
 /**

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -10,8 +10,14 @@ import { startDefaultEndpoint } from './default-endpoint.js'
 export const initPixstoreBackend = (
   config: Partial<PixstoreBackendConfig> = {},
 ) => {
+  // Validates user config (e.g. cleanupBatch must be < cacheLimit)
+  // Then applies it to the internal Pixstore state
   initPixstore(config)
+
+  // Prepares the database for storing image metadata
   initializeDatabase()
+
+  // If enabled, starts the default image-serving HTTP endpoint
   if (pixstoreConfig.defaultEndpointEnabled) {
     startDefaultEndpoint()
   }

--- a/src/frontend/image-service.ts
+++ b/src/frontend/image-service.ts
@@ -27,7 +27,11 @@ export const getImage = async (
   if (cached && cached.token === token) {
     const indexedDBRecord = await readImageRecord(id)
     const encrypted = indexedDBRecord!.encrypted
+
+    // Decrypt the image using the extracted encrypted data and meta
     const imagePayload = await decryptImage(encrypted, meta)
+
+    // Return the up-to-date Blob for rendering
     return decryptedPayloadToBlob(imagePayload)
   }
 
@@ -48,7 +52,8 @@ export const getImage = async (
   // Save the updated image into the local cache
   await writeImageRecord(indexedDBRecord)
 
-  // Decrypt the image using the extracted encrypted data and meta
+  // Decrypt the image using the encrypted data and meta from the wire payload.
+  // The `record.meta` is not used, using stale meta could break decryption if the image was recently updated.
   const imagePayload = await decryptImage(
     decodedWirePayload.encrypted,
     decodedWirePayload.meta,
@@ -62,6 +67,7 @@ export const getImage = async (
  * Removes a cached image from IndexedDB.
  */
 export const deleteCachedImage = async (id: string): Promise<void> => {
+  // Deletes the image record (by ID) from the local IndexedDB cache
   await deleteImageRecord(id)
 }
 
@@ -69,5 +75,6 @@ export const deleteCachedImage = async (id: string): Promise<void> => {
  * Returns true if a cached image exists in IndexedDB for the given id.
  */
 export const cachedImageExists = async (id: string): Promise<boolean> => {
+  // Checks IndexedDB for an image record with the specified ID
   return await imageRecordExists(id)
 }

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -11,9 +11,13 @@ export const initPixstoreFrontend = (
   config: Partial<PixstoreFrontendConfig> = {},
   customImageFetcher?: CustomImageFetcher,
 ) => {
+  // Apply user config to internal state
   initPixstore(config)
+
+  // Register optional image fetcher override
   registerCustomImageFetcher(customImageFetcher)
 }
+
 // Export main image service functions for external use
 export {
   getImage,

--- a/src/types/image-decryption-meta.ts
+++ b/src/types/image-decryption-meta.ts
@@ -1,5 +1,6 @@
+// Metadata required to decrypt an encrypted image
 export interface ImageDecryptionMeta {
-  key: string
-  iv: string
-  tag: string
+  key: string // Base64-encoded AES-GCM encryption key
+  iv: string // Initialization vector (IV) for AES-GCM, base64-encoded
+  tag: string // Authentication tag for AES-GCM, base64-encoded
 }

--- a/src/types/image-record.ts
+++ b/src/types/image-record.ts
@@ -1,7 +1,8 @@
 import type { ImageDecryptionMeta } from './image-decryption-meta.js'
 
+// Reference object representing an image in Pixstore
 export interface ImageRecord {
-  id: string
-  token: number
-  meta: ImageDecryptionMeta
+  id: string // Unique ID used to locate and identify the image
+  token: number // Used for cache validation and version control
+  meta: ImageDecryptionMeta // Metadata required to decrypt the image
 }


### PR DESCRIPTION
This PR provides a comprehensive API reference documentation for Pixstore, covering:

* Backend module: initialization, image service functions, and custom endpoint helper
* Frontend module: initialization, image fetching, cache management, and configuration
* Shared types: `ImageRecord`, `ImageDecryptionMeta`, and related definitions
* Sidebar and category JSON files for structured navigation in the docs

> ⚠️ This is not the final PR for all documentation. Additional updates and frontend refinements will follow in subsequent PRs.