### PR TITLE
feat: secure stateless default endpoint & wire protocol refactor (BREAKING CHANGE)

### DIFF
--- a/examples/example-1-nest-vue-default-endpoint/README.md
+++ b/examples/example-1-nest-vue-default-endpoint/README.md
@@ -66,12 +66,19 @@ Go to [http://localhost:5173/](http://localhost:5173/) in your browser.
 
 ---
 
+> **Stateless Proof Expiry:**  
+> This example uses `STATELESS_KEY_WINDOWS_LENGTH = -1` for uninterrupted image access.
+> You can **test stateless proof expiry** by setting it to any positive value.
+> After expiry, images cannot be fetched again without reloading the page or refetching all ImageRecords.
+
+---
+
 ## **Note**
 
 - In production, you’d use much higher cache limits!
 - You can adjust `FRONTEND_IMAGE_CACHE_LIMIT` and `FRONTEND_CLEANUP_BATCH` in `frontend/src/main.ts` to experiment.
 - Pixstore is imported from a local build for demo purposes. In your own project, just use:
-z"
+  z"
   ```js
   import { getImage } from 'pixstore/frontend'
   ```

--- a/examples/example-1-nest-vue-default-endpoint/backend/src/image-record.entity.ts
+++ b/examples/example-1-nest-vue-default-endpoint/backend/src/image-record.entity.ts
@@ -28,4 +28,7 @@ export class ImageRecord implements ImageRecordModel {
 
   @Field(() => ImageMeta)
   meta: ImageMeta;
+
+  @Field(() => String)
+  statelessProof: string;
 }

--- a/examples/example-1-nest-vue-default-endpoint/backend/src/init-pixstore.ts
+++ b/examples/example-1-nest-vue-default-endpoint/backend/src/init-pixstore.ts
@@ -33,6 +33,15 @@ const DEFAULT_ENDPOINT_PORT = 4000;
 // For local development, this should match your frontend's dev server (e.g. Vite).
 const ACCESS_CONTROL_ALLOW_ORIGIN = 'http://localhost:5173';
 
+// Stateless proof window length in milliseconds.
+// - Set to a positive integer (e.g. 60000) to require proof rotation (for enhanced security).
+// - Set to -1 to disable proof expiry and allow non-expiring proofs (not recommended for production).
+//
+// IMPORTANT: In this example, **all ImageRecords are fetched at once** (on page load).
+// If you use a value other than -1, the stateless proof will expire after the configured time window.
+// After expiry, images cannot be fetched without refreshing the page (to obtain fresh proofs).
+const STATELESS_KEY_WINDOWS_LENGTH = -1;
+
 /**
  * Initializes Pixstore backend with a clean database and image directory.
  * - Removes old data by calling clearOldPixstore()
@@ -46,5 +55,6 @@ export const initPixstore = () => {
     databasePath: DATABASE_PATH,
     defaultEndpointListenPort: DEFAULT_ENDPOINT_PORT,
     accessControlAllowOrigin: ACCESS_CONTROL_ALLOW_ORIGIN,
+    statelessKeyWindowLength: STATELESS_KEY_WINDOWS_LENGTH,
   });
 };

--- a/examples/example-1-nest-vue-default-endpoint/backend/src/rm-player.resolver.ts
+++ b/examples/example-1-nest-vue-default-endpoint/backend/src/rm-player.resolver.ts
@@ -18,6 +18,7 @@ const backendRecordToGql = (record: ImageRecord): ImageRecord => {
       iv: record.meta.iv,
       tag: record.meta.tag,
     },
+    statelessProof: record.statelessProof,
   };
 };
 

--- a/examples/example-1-nest-vue-default-endpoint/frontend/src/stores/RMPlayers.ts
+++ b/examples/example-1-nest-vue-default-endpoint/frontend/src/stores/RMPlayers.ts
@@ -52,6 +52,7 @@ export const useRMPlayersStore = defineStore('RMPlayers', {
                     iv
                     tag
                   }
+                  statelessProof
                 }
               }
             }

--- a/examples/example-1-nest-vue-default-endpoint/package.json
+++ b/examples/example-1-nest-vue-default-endpoint/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "start": "npm run dev",
+    "predev": "cd ../../ && npm run build",
     "dev": "concurrently \"npm run start:backend\" \"npm run start:frontend\"",
     "start:backend": "npm --workspace=backend run start",
     "start:frontend": "npm --workspace=frontend run dev"

--- a/examples/example-2-express-react-custom-endpoint/README.md
+++ b/examples/example-2-express-react-custom-endpoint/README.md
@@ -134,4 +134,6 @@ export const getPlayerImage = async (
 - In production, you’d want more robust authentication and error handling.
 - Adjust cache limits in the Pixstore frontend config to test cleanup behavior.
 
+---
+
 **Explore strict, secure, and modern image storage with Pixstore!**

--- a/examples/example-2-express-react-custom-endpoint/backend/src/controllers/player.ts
+++ b/examples/example-2-express-react-custom-endpoint/backend/src/controllers/player.ts
@@ -1,5 +1,9 @@
-// Import Pixstore from the official package.
-import { getImageRecord } from 'pixstore/backend'
+// IMPORTANT: In this example, Pixstore is imported directly from a local build path for demonstration purposes.
+// In real projects, you should install Pixstore via npm and import as follows:
+//
+//   import { initPixstoreBackend } from 'pixstore/backend'
+//
+import { getImageRecord } from '../../../../../dist/backend'
 
 import { getPlayerById } from '../store/in-memory-db'
 import { Request, Response } from 'express'

--- a/examples/example-2-express-react-custom-endpoint/backend/src/models/basketball-player.ts
+++ b/examples/example-2-express-react-custom-endpoint/backend/src/models/basketball-player.ts
@@ -1,5 +1,9 @@
-// Import Pixstore from the official package.
-import { ImageRecord } from 'pixstore/types'
+// IMPORTANT: In this example, Pixstore is imported directly from a local build path for demonstration purposes.
+// In real projects, you should install Pixstore via npm and import as follows:
+//
+//   import { initPixstoreBackend } from 'pixstore/backend'
+//
+import { ImageRecord } from '../../../../../dist/types'
 
 export interface BasketballPlayerRecord {
   id: number

--- a/examples/example-2-express-react-custom-endpoint/backend/src/store/init-pixstore.ts
+++ b/examples/example-2-express-react-custom-endpoint/backend/src/store/init-pixstore.ts
@@ -1,5 +1,9 @@
-// Import Pixstore backend initializer from the official package.
-import { initPixstoreBackend } from 'pixstore/backend'
+// IMPORTANT: In this example, Pixstore is imported directly from a local build path for demonstration purposes.
+// In real projects, you should install Pixstore via npm and import as follows:
+//
+//   import { initPixstoreBackend } from 'pixstore/backend'
+//
+import { initPixstoreBackend } from '../../../../../dist/backend'
 import * as fs from 'fs'
 
 // Path for storing Pixstore image files

--- a/examples/example-2-express-react-custom-endpoint/backend/src/store/seed-database.ts
+++ b/examples/example-2-express-react-custom-endpoint/backend/src/store/seed-database.ts
@@ -1,5 +1,9 @@
-// Import Pixstore backend initializer from the official package.
-import { saveImage } from 'pixstore/backend'
+// IMPORTANT: In this example, Pixstore is imported directly from a local build path for demonstration purposes.
+// In real projects, you should install Pixstore via npm and import as follows:
+//
+//   import { initPixstoreBackend } from 'pixstore/backend'
+//
+import { saveImage } from '../../../../../dist/backend'
 
 import {
   addTeam,

--- a/examples/example-2-express-react-custom-endpoint/frontend/src/components/player/PlayerCard.tsx
+++ b/examples/example-2-express-react-custom-endpoint/frontend/src/components/player/PlayerCard.tsx
@@ -1,6 +1,10 @@
-// Import Pixstore backend initializer from the official package.
-import { getImage } from 'pixstore/frontend/'
-import type { ImageRecord } from 'pixstore/types'
+// IMPORTANT: In this example, Pixstore is imported directly from a local build path for demonstration purposes.
+// In real projects, you should install Pixstore via npm and import as follows:
+//
+//   import { initPixstoreBackend } from 'pixstore/backend'
+//
+import { getImage } from '../../../../../../dist/frontend/'
+import type { ImageRecord } from '../../../../../../dist/types'
 
 import { useState, useEffect } from 'react'
 import { useAuth } from '../../store/auth'

--- a/examples/example-2-express-react-custom-endpoint/frontend/src/main.tsx
+++ b/examples/example-2-express-react-custom-endpoint/frontend/src/main.tsx
@@ -1,14 +1,14 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import "./index.css";
-import App from "./App.tsx";
-import { initPixstore } from "./init-pixstore.ts";
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+import { initPixstore } from './init-pixstore.ts'
 
 // Initialize Pixstore frontend with custom image fetcher integration (see ./init-pixstore.ts)
-initPixstore();
+initPixstore()
 
-createRoot(document.getElementById("root")!).render(
+createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>
-);
+  </StrictMode>,
+)

--- a/examples/example-2-express-react-custom-endpoint/package.json
+++ b/examples/example-2-express-react-custom-endpoint/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "start": "npm run dev",
+    "predev": "cd ../../ && npm run build",
     "dev": "concurrently \"npm run start:backend\" \"npm run start:frontend\"",
     "start:backend": "npm --workspace=backend run start",
     "start:frontend": "npm --workspace=frontend run dev"

--- a/src/backend/custom-endpoint.ts
+++ b/src/backend/custom-endpoint.ts
@@ -3,14 +3,20 @@ import { encodeWirePayload } from '../shared/wire-encoder.js'
 import { isServerStarted } from './default-endpoint.js'
 import { handleErrorAsync } from '../shared/handle-error.js'
 import { PixstoreError } from '../shared/pixstore-error.js'
+import { verifyStatelessProof } from './stateless-proof.js'
+import { WirePayloadState } from '../types/wire-payload.js'
 
 /**
- * Returns a Pixstore wire format encoded image payload (Uint8Array) for the given image id.
- * Throws if the default endpoint is running, to prevent accidental double endpoint use.
- * Can be used in any custom endpoint handler to build a response.
+ * Returns a Pixstore wire format encoded image payload (Uint8Array) for the given image ID.
+ * Throws if the default endpoint is running, to prevent accidental dual endpoint usage.
+ * Can be used in any custom endpoint handler to build a secure response.
+ *
+ * All security checks (stateless proof, image tag, etc.) are enforced before generating the payload.
  */
 export const customEndpointHelper = async (
-  id: string,
+  imageId: string,
+  clientToken: number | undefined,
+  statelessProof: string,
 ): Promise<Uint8Array | null> => {
   return handleErrorAsync(async () => {
     // Prevent usage if the default endpoint is active (safety guard)
@@ -19,11 +25,46 @@ export const customEndpointHelper = async (
         'Pixstore custom endpoint mode is not active. Please disable the default endpoint before using customEndpointHelper().',
       )
     }
-
-    // Fetch decrypted image and metadata as a wire payload structure
-    const wirePayload = await getWirePayload(id)
-
-    // Encode it as Uint8Array in Pixstore wire format (used by frontend to decode)
-    return encodeWirePayload(wirePayload)
+    // Perform all security and wire checks
+    return await endpointHelper(imageId, clientToken, statelessProof)
   })
+}
+
+/**
+ * Generates an encoded Pixstore wire payload for the requested image ID.
+ *
+ * - Validates the provided statelessProof and clientToken before serving any image data.
+ * - On any missing or invalid input, returns a payload with the appropriate WirePayloadState.
+ * - If the stateless proof is valid, calls getWirePayload to return the correct payload variant
+ *   (Success, Updated, NotFound).
+ * - Catches any unexpected errors and returns an InternalError state.
+ *
+ * Always returns an encoded Uint8Array wire payload,
+ * with the state as the first byte for protocol-agnostic error handling.
+ */
+export const endpointHelper = async (
+  imageId: string | undefined,
+  clientToken: number | undefined,
+  statelessProof: string | undefined,
+): Promise<Uint8Array> => {
+  try {
+    // Validate parameters
+    if (!imageId)
+      return encodeWirePayload({ state: WirePayloadState.MissingID })
+    if (!statelessProof)
+      return encodeWirePayload({ state: WirePayloadState.MissingProof })
+
+    // Validate the stateless proof-of-access key (time-based)
+    if (!verifyStatelessProof(imageId, statelessProof)) {
+      return encodeWirePayload({ state: WirePayloadState.InvalidProof })
+    }
+
+    // Fetch the decrypted image and its metadata as a wire payload structure
+    const wirePayload = await getWirePayload(imageId, clientToken)
+
+    // Encode as Uint8Array in Pixstore wire format (consumed by the frontend)
+    return encodeWirePayload(wirePayload)
+  } catch {
+    return encodeWirePayload({ state: WirePayloadState.InternalError })
+  }
 }

--- a/src/backend/database.ts
+++ b/src/backend/database.ts
@@ -1,6 +1,6 @@
 import BetterSqlite3 from 'better-sqlite3'
 
-import type { ImageRecord } from '../types/image-record.js'
+import type { DBImageRecord } from '../types/image-record.js'
 import { pixstoreConfig } from '../shared/pixstore-config.js'
 import { ImageDecryptionMeta } from '../types/image-decryption-meta.js'
 
@@ -35,7 +35,7 @@ export const initializeDatabase = () => {
 export const writeImageRecord = (
   id: string,
   meta: ImageDecryptionMeta,
-): ImageRecord => {
+): DBImageRecord => {
   const token = Date.now()
   const metaJSON = JSON.stringify(meta)
   const statement = database!.prepare(
@@ -52,7 +52,7 @@ export const writeImageRecord = (
  * Retrieves the image record with the given ID.
  * Returns null if the record does not exist.
  */
-export const readImageRecord = (id: string): ImageRecord | null => {
+export const readImageRecord = (id: string): DBImageRecord | null => {
   const row = database!
     .prepare(`SELECT id, token, meta FROM image_records WHERE id = ?`)
     .get(id) as { id: string; token: number; meta: string } | undefined

--- a/src/backend/stateless-proof.ts
+++ b/src/backend/stateless-proof.ts
@@ -1,0 +1,70 @@
+import crypto from 'crypto'
+import { STATELESS_KEY_LENGTH } from '../shared/constants.js'
+import { pixstoreConfig } from '../shared/pixstore-config.js'
+
+/**
+ * Random, per-process salt for stateless proof generation.
+ * Never exported or persisted, created fresh on every server start.
+ * If this value is leaked, stateless proof security is broken.
+ */
+const SERVER_SALT = crypto.randomBytes(32)
+
+/**
+ * Stateless proof generator.
+ * Returns a deterministic N-byte proof for a given image ID and time window,
+ * using the per-process salt.
+ */
+const createProof = (window: number | null, imageId: string): string => {
+  const hash = window
+    ? crypto
+        .createHash('sha256')
+        .update(imageId)
+        .update(SERVER_SALT)
+        .update(window.toString())
+        .digest()
+    : crypto.createHash('sha256').update(imageId).update(SERVER_SALT).digest()
+  // Only the first N bytes are used as proof, defined in config/constants.
+  return hash.subarray(0, STATELESS_KEY_LENGTH).toString('base64')
+}
+
+/**
+ * Returns the current window's stateless proof for the given image ID.
+ * Used to validate access for the current time slot.
+ */
+export const getCurrentStatelessProof = (imageId: string): string => {
+  const STATELESS_KEY_WINDOW_LENGTH = pixstoreConfig.statelessKeyWindowLength
+  if (STATELESS_KEY_WINDOW_LENGTH === -1) return createProof(null, imageId)
+
+  const window = Math.floor(Date.now() / STATELESS_KEY_WINDOW_LENGTH)
+  return createProof(window, imageId)
+}
+
+/**
+ * Returns the previous window's stateless proof for the given image ID.
+ * Used to allow clock drift and slow network. Two consecutive proofs are valid.
+ */
+export const getPreviousStatelessProof = (imageId: string): string => {
+  const STATELESS_KEY_WINDOW_LENGTH = pixstoreConfig.statelessKeyWindowLength
+  if (STATELESS_KEY_WINDOW_LENGTH === -1) return createProof(null, imageId)
+
+  const window = Math.floor(Date.now() / STATELESS_KEY_WINDOW_LENGTH)
+  return createProof(window - 1, imageId)
+}
+
+/**
+ * Validates a received proof against both current and previous window for a given image ID.
+ * Returns true if the proof matches either; otherwise, false.
+ * Accepts slight clock/network drift and ensures user experience.
+ */
+export const verifyStatelessProof = (
+  imageId: string,
+  proof: string,
+): boolean => {
+  const currentProof = getCurrentStatelessProof(imageId)
+  if (currentProof === proof) return true
+
+  const previousProof = getPreviousStatelessProof(imageId)
+  if (previousProof === proof) return true
+
+  return false
+}

--- a/src/frontend/custom-image-fetcher.ts
+++ b/src/frontend/custom-image-fetcher.ts
@@ -1,4 +1,4 @@
-import type { CustomImageFetcher } from '../types/custom-image-fetcher.js'
+import type { CustomImageFetcher } from '../types/image-fetcher.js'
 
 /**
  * Stores the current custom fetcher function if registered by the user.
@@ -12,6 +12,9 @@ let customImageFetcher: CustomImageFetcher | undefined
 export const registerCustomImageFetcher = (
   fetcher: CustomImageFetcher | undefined,
 ) => {
+  if (customImageFetcher && fetcher) {
+    console.warn('Overwriting existing custom image fetcher.')
+  }
   customImageFetcher = fetcher
 }
 

--- a/src/frontend/default-image-fetcher.ts
+++ b/src/frontend/default-image-fetcher.ts
@@ -1,21 +1,37 @@
 import { pixstoreConfig } from '../shared/pixstore-config.js'
 import { PixstoreError } from '../shared/pixstore-error.js'
+import type { ImageFetcher } from '../types/image-fetcher.js'
 
 /**
- * Fetches a raw encoded image payload from the Pixstore backend.
+ * Fetches a raw encoded image payload from the Pixstore backend default endpoint.
  *
  * This performs a direct HTTP GET request to the default image endpoint using
- * the wire format protocol: [1 byte format][8 byte token][N bytes buffer].
+ * the current wire protocol (status byte, token, stateless proof in headers).
  */
-const defaultImageFetcher = async (id: string): Promise<Uint8Array> => {
+const defaultImageFetcher: ImageFetcher = async (
+  parameters,
+): Promise<Uint8Array> => {
+  const {
+    imageId,
+    imageToken,
+    statelessProof,
+    // context (optional, ignored here)
+  } = parameters
+
   const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointConnectPort
   const DEFAULT_ENDPOINT_ROUTE = pixstoreConfig.defaultEndpointRoute
   const SERVER_HOST = pixstoreConfig.defaultEndpointConnectHost
-  // Construct the full URL using constants
-  const url = `http://${SERVER_HOST}:${DEFAULT_ENDPOINT_PORT}${DEFAULT_ENDPOINT_ROUTE}/${encodeURIComponent(id)}`
+
+  // Construct the full URL using constants and provided imageId
+  const url = `http://${SERVER_HOST}:${DEFAULT_ENDPOINT_PORT}${DEFAULT_ENDPOINT_ROUTE}/${encodeURIComponent(imageId)}`
+
+  // Prepare headers for proof and token (only if defined)
+  const headers: Record<string, string> = {}
+  if (statelessProof) headers['x-pixstore-proof'] = statelessProof
+  if (imageToken !== undefined) headers['x-pixstore-token'] = String(imageToken)
 
   // Perform the HTTP request
-  const res = await fetch(url)
+  const res = await fetch(url, { method: 'GET', headers })
 
   // Ensure the response is OK (200-level)
   if (!res.ok) {
@@ -26,9 +42,7 @@ const defaultImageFetcher = async (id: string): Promise<Uint8Array> => {
 
   // Read and convert response body to Uint8Array
   const buffer = await res.arrayBuffer()
-  const uint8 = new Uint8Array(buffer)
-
-  return uint8
+  return new Uint8Array(buffer)
 }
 
 export const getDefaultImageFetcher = () => defaultImageFetcher

--- a/src/frontend/image-fetcher.ts
+++ b/src/frontend/image-fetcher.ts
@@ -1,3 +1,4 @@
+import { ImageFetcher } from '../types/image-fetcher.js'
 import { getCustomImageFetcher } from './custom-image-fetcher.js'
 import { getDefaultImageFetcher } from './default-image-fetcher.js'
 
@@ -6,15 +7,12 @@ import { getDefaultImageFetcher } from './default-image-fetcher.js'
  * (if registered) or the default Pixstore fetcher.
  * Always returns the wire-format Uint8Array for the given image id.
  */
-export const fetchEncodedImage = async (
-  id: string,
-  context?: any,
-): Promise<Uint8Array> => {
+export const fetchEncodedImage: ImageFetcher = async (parameters) => {
   const customImageFetcher = getCustomImageFetcher()
 
   if (customImageFetcher) {
-    return customImageFetcher(id, context)
+    return customImageFetcher(parameters)
   }
   const defaultImageFetcher = getDefaultImageFetcher()
-  return defaultImageFetcher(id)
+  return defaultImageFetcher(parameters)
 }

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -1,7 +1,7 @@
 import type { PixstoreFrontendConfig } from '../types/pixstore-config.js'
 import { initPixstore } from '../shared/pixstore-config.js'
 import { registerCustomImageFetcher } from './custom-image-fetcher.js'
-import type { CustomImageFetcher } from '../types/custom-image-fetcher.js'
+import type { CustomImageFetcher } from '../types/image-fetcher.js'
 
 /**
  * Initializes the Pixstore frontend module with the given configuration.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -32,3 +32,10 @@ export const AES_IV_SIZE = 12
  * Authentication tag length for AES-GCM (in bits, standard is 128)
  */
 export const AES_GCM_TAG_LENGTH = 128
+
+/**
+ * Length of the stateless proof-of-access key in bytes.
+ * This is the number of bytes taken from the SHA-256 hash to use as the proof.
+ * Typical value is 8 bytes (64 bits), which provides strong security for short-lived proofs.
+ */
+export const STATELESS_KEY_LENGTH = 8

--- a/src/shared/pixstore-config.ts
+++ b/src/shared/pixstore-config.ts
@@ -58,6 +58,16 @@ const validateConfig = (config: Partial<PixstoreConfig>): void => {
 
   validatePort('defaultEndpointListenPort', config.defaultEndpointListenPort)
   validatePort('defaultEndpointConnectPort', config.defaultEndpointConnectPort)
+
+  // statelessKeyWindowLength must be -1 (no expiry) or a positive integer (ms)
+  if (config.statelessKeyWindowLength !== undefined) {
+    const val = config.statelessKeyWindowLength
+    if (val !== -1 && (!Number.isFinite(val) || val <= 0)) {
+      throw new Error(
+        'statelessKeyWindowLength must be a positive integer (milliseconds) or -1 for non-expiring proof',
+      )
+    }
+  }
 }
 
 const DEFAULT_ENDPOINT_TEST_PORT = 10000 + Math.floor(Math.random() * 50000)
@@ -72,6 +82,8 @@ export const defaultConfig: PixstoreConfig = {
   imageExtension: '.pixstore-image',
   imageRootDir: IS_TEST ? 'pixstore-test-images' : 'pixstore-images',
   databasePath: IS_TEST ? './.pixstore-test.sqlite' : './.pixstore.sqlite',
+  statelessKeyWindowLength: IS_TEST ? 200 : 20000,
+
   defaultEndpointEnabled: true,
   defaultEndpointRoute: '/pixstore-image',
   defaultEndpointListenHost: IS_TEST ? '127.0.0.1' : '0.0.0.0',

--- a/src/shared/wire-encoder.ts
+++ b/src/shared/wire-encoder.ts
@@ -1,4 +1,7 @@
-import type { BackendWirePayload } from '../types/wire-payload.js'
+import {
+  WirePayloadState,
+  type BackendWirePayload,
+} from '../types/wire-payload.js'
 import type { FrontendWirePayload } from '../types/wire-payload.js'
 import {
   AES_KEY_SIZE,
@@ -7,31 +10,62 @@ import {
 } from '../shared/constants.js'
 import { ImageDecryptionMeta } from '../types/image-decryption-meta.js'
 import { arrayBufferToBase64, base64ToArrayBuffer } from './format-buffer.js'
+import { PixstoreError } from './pixstore-error.js'
 
 const TAG_SIZE_BYTES = AES_GCM_TAG_LENGTH / 8
 
 /**
  * Encodes a BackendWirePayload into a binary Uint8Array.
- * Layout: [token (8 bytes, LE)] [key (32 bytes)] [iv (12 bytes)]
- *         [tag (16 bytes)] [encrypted image buffer]
+ *
+ * Wire protocol:
+ *   - [state (1 byte)] [encrypted image buffer]                          // Success
+ *   - [state (1 byte)] [token (8 bytes, LE)] [key (32 bytes)]            // Updated
+ *     [iv (12 bytes)] [tag (16 bytes)] [encrypted image buffer]
+ *   - [state (1 byte)]                                                   // All other states
  */
 export const encodeWirePayload = (payload: BackendWirePayload): Uint8Array => {
+  const { state } = payload
+
+  // Validate that the state is a valid WirePayloadState
+  validateState(state)
+
+  // For non-Success and non-Updated states, encode as [state]
+  if (
+    state !== WirePayloadState.Success &&
+    state !== WirePayloadState.Updated
+  ) {
+    const result = new Uint8Array(1)
+    result[0] = state
+    return result
+  }
+
+  // For Success state, encode as [state][encrypted]
+  if (state === WirePayloadState.Success) {
+    const { encrypted } = payload
+    const result = new Uint8Array(1 + encrypted.byteLength)
+    result[0] = state
+    result.set(new Uint8Array(encrypted), 1)
+    return result
+  }
+
+  // For Updated state, encode as [state][token][key][iv][tag][encrypted]
   const { token, meta, encrypted } = payload
 
-  // Convert base64 string to ArrayBuffer
   const keyBuf = base64ToArrayBuffer(meta.key)
   const ivBuf = base64ToArrayBuffer(meta.iv)
   const tagBuf = base64ToArrayBuffer(meta.tag)
 
-  // Token as 8 bytes (LE)
+  // Encode token as 8 bytes (LE)
   const tokenBuf = new ArrayBuffer(8)
   new DataView(tokenBuf).setBigUint64(0, BigInt(token), true)
 
-  const total =
-    8 + AES_KEY_SIZE + AES_IV_SIZE + TAG_SIZE_BYTES + encrypted.byteLength
-  const result = new Uint8Array(total)
+  const totalLength =
+    1 + 8 + AES_KEY_SIZE + AES_IV_SIZE + TAG_SIZE_BYTES + encrypted.byteLength
 
+  const result = new Uint8Array(totalLength)
   let offset = 0
+
+  result[offset++] = state
   result.set(new Uint8Array(tokenBuf), offset)
   offset += 8
 
@@ -49,52 +83,89 @@ export const encodeWirePayload = (payload: BackendWirePayload): Uint8Array => {
 }
 
 /**
- * Decodes a Uint8Array into a FrontendWirePayload.
- * Expects the same layout as above.
+ * Decodes a binary wire payload (Uint8Array) into a FrontendWirePayload.
+ * Layout:
+ *   - [state (1 byte)] [encrypted image buffer]                          // Success
+ *   - [state (1 byte)] [token (8 bytes, LE)] [key (32 bytes)]            // Updated
+ *     [iv (12 bytes)] [tag (16 bytes)] [encrypted image buffer]
+ *   - [state (1 byte)]                                                   // All other states
  */
 export const decodeWirePayload = (data: Uint8Array): FrontendWirePayload => {
   let offset = 0
+  const state = data[offset++]
 
-  // 1) token
-  const token = Number(
-    new DataView(data.buffer, data.byteOffset + offset, 8).getBigUint64(
-      0,
-      true,
-    ),
-  )
-  offset += 8
+  // Validate that the state is a valid WirePayloadState
+  validateState(state)
 
-  // 2) key
-  const keySlice = data.subarray(offset, offset + AES_KEY_SIZE)
-  const key = keySlice.buffer.slice(
-    keySlice.byteOffset,
-    keySlice.byteOffset + keySlice.byteLength,
-  ) as ArrayBuffer
-  offset += AES_KEY_SIZE
-
-  // 3) iv
-  const ivSlice = data.subarray(offset, offset + AES_IV_SIZE)
-  const iv = ivSlice.buffer.slice(
-    ivSlice.byteOffset,
-    ivSlice.byteOffset + ivSlice.byteLength,
-  ) as ArrayBuffer
-  offset += AES_IV_SIZE
-
-  // 4) tag
-  const tagSlice = data.subarray(offset, offset + TAG_SIZE_BYTES)
-  const tag = tagSlice.buffer.slice(
-    tagSlice.byteOffset,
-    tagSlice.byteOffset + tagSlice.byteLength,
-  ) as ArrayBuffer
-  offset += TAG_SIZE_BYTES
-
-  // 5) encrypted buffer
-  const encrypted = data.subarray(offset)
-
-  const meta: ImageDecryptionMeta = {
-    key: arrayBufferToBase64(key),
-    iv: arrayBufferToBase64(iv),
-    tag: arrayBufferToBase64(tag),
+  // If only 1 byte, just return the state (NotFound, MissingToken, etc.)
+  if (data.length === 1) {
+    return { state }
   }
-  return { token, meta, encrypted }
+
+  // Success: [state][encrypted]
+  if (state === WirePayloadState.Success) {
+    const encrypted = data.subarray(offset)
+    return { state, encrypted }
+  }
+
+  // Updated: [state][token][key][iv][tag][encrypted]
+  if (state === WirePayloadState.Updated) {
+    // 1) token
+    const token = Number(
+      new DataView(data.buffer, data.byteOffset + offset, 8).getBigUint64(
+        0,
+        true,
+      ),
+    )
+    offset += 8
+
+    // 2) key
+    const keySlice = data.subarray(offset, offset + AES_KEY_SIZE)
+    const key = keySlice.buffer.slice(
+      keySlice.byteOffset,
+      keySlice.byteOffset + keySlice.byteLength,
+    ) as ArrayBuffer
+    offset += AES_KEY_SIZE
+
+    // 3) iv
+    const ivSlice = data.subarray(offset, offset + AES_IV_SIZE)
+    const iv = ivSlice.buffer.slice(
+      ivSlice.byteOffset,
+      ivSlice.byteOffset + ivSlice.byteLength,
+    ) as ArrayBuffer
+    offset += AES_IV_SIZE
+
+    // 4) tag
+    const tagSlice = data.subarray(offset, offset + TAG_SIZE_BYTES)
+    const tag = tagSlice.buffer.slice(
+      tagSlice.byteOffset,
+      tagSlice.byteOffset + tagSlice.byteLength,
+    ) as ArrayBuffer
+    offset += TAG_SIZE_BYTES
+
+    // 5) encrypted buffer
+    const encrypted = data.subarray(offset)
+
+    const meta: ImageDecryptionMeta = {
+      key: arrayBufferToBase64(key),
+      iv: arrayBufferToBase64(iv),
+      tag: arrayBufferToBase64(tag),
+    }
+    return { state, token, meta, encrypted }
+  }
+
+  // Fallback: Return just state
+  return { state }
+}
+
+/**
+ * Checks whether the given state is a valid WirePayloadState enum value.
+ * Throws PixstoreError if the state is unknown, to prevent encoding or decoding invalid payloads.
+ */
+const validateState = (state: WirePayloadState) => {
+  if (!Object.values(WirePayloadState).includes(state)) {
+    throw new PixstoreError(
+      `encodeWirePayload: Invalid state=${state} in BackendWirePayload`,
+    )
+  }
 }

--- a/src/types/custom-image-fetcher.ts
+++ b/src/types/custom-image-fetcher.ts
@@ -1,4 +1,0 @@
-export type CustomImageFetcher = (
-  id: string,
-  context?: any,
-) => Promise<Uint8Array>

--- a/src/types/image-fetcher.ts
+++ b/src/types/image-fetcher.ts
@@ -1,0 +1,8 @@
+export type ImageFetcher = (parameters: {
+  imageId: string
+  imageToken: number | undefined
+  statelessProof: string
+  context?: any
+}) => Promise<Uint8Array>
+
+export type CustomImageFetcher = ImageFetcher

--- a/src/types/image-record.ts
+++ b/src/types/image-record.ts
@@ -5,4 +5,12 @@ export interface ImageRecord {
   id: string // Unique ID used to locate and identify the image
   token: number // Used for cache validation and version control
   meta: ImageDecryptionMeta // Metadata required to decrypt the image
+  statelessProof: string // Stateless time-based proof-of-access hash for endpoint authorization
+}
+
+/** Used only for backend (disk/db/cache) */
+export interface DBImageRecord {
+  id: string
+  token: number
+  meta: ImageDecryptionMeta
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,9 @@
-// Export image record type
+/**
+ * Core image record type for use with getImage() and all Pixstore APIs.
+ */
 export type { ImageRecord } from './image-record.js'
+
+/**
+ * ImageFetcher type for registering custom or default image fetchers.
+ */
+export type { ImageFetcher } from './image-fetcher.js'

--- a/src/types/pixstore-config.ts
+++ b/src/types/pixstore-config.ts
@@ -1,10 +1,11 @@
 import type { ImageFormat } from './image-format.js'
-import type { ErrorHandlingMode } from './error-handling-mode.ts'
+import type { ErrorHandlingMode } from './error-handling-mode.js'
 
 export interface PixstoreBackendConfig {
   imageFormats: readonly ImageFormat[]
   imageRootDir: string
   databasePath: string
+  statelessKeyWindowLength: number
   defaultEndpointEnabled: boolean
   defaultEndpointListenHost: string
   defaultEndpointListenPort: number

--- a/src/types/wire-payload.ts
+++ b/src/types/wire-payload.ts
@@ -1,13 +1,53 @@
 import { ImageDecryptionMeta } from './image-decryption-meta.js'
 
-export interface BackendWirePayload {
-  encrypted: Buffer
-  meta: ImageDecryptionMeta
-  token: number
-}
+export type BackendWirePayload =
+  | {
+      state: WirePayloadState.Success
+      encrypted: Buffer
+    }
+  | {
+      state: WirePayloadState.Updated
+      encrypted: Buffer
+      meta: ImageDecryptionMeta
+      token: number
+    }
+  | {
+      state: Exclude<
+        WirePayloadState,
+        WirePayloadState.Success | WirePayloadState.Updated
+      >
+      // No payload fields, only state
+    }
 
-export interface FrontendWirePayload {
-  encrypted: Uint8Array
-  meta: ImageDecryptionMeta
-  token: number
+export type FrontendWirePayload =
+  | {
+      state: WirePayloadState.Success
+      encrypted: Uint8Array
+    }
+  | {
+      state: WirePayloadState.Updated
+      encrypted: Uint8Array
+      meta: ImageDecryptionMeta
+      token: number
+    }
+  | {
+      state: Exclude<
+        WirePayloadState,
+        WirePayloadState.Success | WirePayloadState.Updated
+      >
+      // No payload fields, only state
+    }
+
+export enum WirePayloadState {
+  Success = 0, // All OK, minimal payload (encrypted image only)
+  Updated = 1, // Token mismatch, full payload returned
+  NotFound = 2, // Image not found
+  MissingID = 3, // Image ID missing from request
+  MissingProof = 4, // Stateless proof missing
+  InvalidProof = 5, // Stateless proof invalid or expired
+  InternalError = 6, // Internal server error (reserved for future use)
+  // InvalidToken = 7, // Client token invalid or unparseable
+  // Unauthorized = 8, // Not authorized (reserved for future use)
+  // RateLimited = 9, // (may be added in future)
+  // UnsupportedFormat = 10,
 }

--- a/tests/modules/backend/image-service.test.ts
+++ b/tests/modules/backend/image-service.test.ts
@@ -13,163 +13,141 @@ import {
   readImageRecord,
 } from '../../../src/backend/database.js'
 import { toFilePath } from '../../../src/backend/unique-id.js'
+import { PixstoreError } from '../../../src/shared/pixstore-error.js'
+import { WirePayloadState } from '../../../src/types/wire-payload.js'
 
 const assetsDir = path.resolve(__dirname, '../../assets')
-import { sleep } from '../../utils'
+
+// Helper to simulate async sleep for file timestamp changes
+const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
 beforeAll(() => {
   initializeDatabase()
 })
 
-describe('saveImageFromFile', () => {
-  const testDir = 'saveImageFromFile'
+describe('Pixstore backend image-service', () => {
+  const testDir = 'backend-image-service'
 
-  it('should save a valid image and create a DB record with dir prefix', async () => {
+  it('should save a valid image and create a DB record', async () => {
     const filePath = path.join(assetsDir, '1-pixel.png')
     const record = await saveImageFromFile(filePath, testDir)
 
-    // file on disk
+    expect(record).not.toBeNull()
+    // File exists on disk
     expect(fs.existsSync(toFilePath(record!.id))).toBe(true)
-
-    // DB record must exist and match id+token
-    const dbRecord = readImageRecord(record!.id)!
+    // DB record exists and matches
+    const dbRecord = readImageRecord(record!.id)
+    expect(dbRecord).not.toBeNull()
     expect(dbRecord!.id).toBe(record!.id)
     expect(dbRecord!.token).toBe(record!.token)
-
-    // metadata must be present
     expect(dbRecord!.meta).toBeDefined()
     expect(dbRecord!.meta.key).toBeDefined()
     expect(dbRecord!.meta.iv).toBeDefined()
     expect(dbRecord!.meta.tag).toBeDefined()
   })
 
-  it('should save a valid image and create a DB record with no dir', async () => {
-    const filePath = path.join(assetsDir, '1-pixel.png')
-    const record = await saveImageFromFile(filePath)
-
-    expect(fs.existsSync(toFilePath(record!.id))).toBe(true)
-    const dbRecord = readImageRecord(record!.id)!
-    expect(dbRecord!.id).toBe(record!.id)
-    expect(dbRecord!.token).toBe(record!.token)
-  })
-
-  it('should reject when given a non-image file', async () => {
+  it('should reject non-image files', async () => {
     const filePath = path.join(assetsDir, 'no-text.txt')
     await expect(saveImageFromFile(filePath, testDir)).rejects.toThrow(
       'Invalid image file',
     )
   })
-})
 
-describe('updateImageFromFile', () => {
-  const testDir = 'updateImageFromFile'
-
-  it('should overwrite existing image and update its token', async () => {
-    const originalPath = path.join(assetsDir, '1-pixel.png')
-    const original = await saveImageFromFile(originalPath, testDir)
-
+  it('should update an image and change its token', async () => {
+    const filePath = path.join(assetsDir, '1-pixel.png')
+    const record = await saveImageFromFile(filePath, testDir)
     await sleep(5)
-
-    const updated = await updateImageFromFile(original!.id, originalPath)
-
-    expect(updated!.id).toBe(original!.id)
-    expect(updated!.token).not.toBe(original!.token)
-
-    // DB record was updated
-    const dbRecord = readImageRecord(updated!.id)!
+    const updated = await updateImageFromFile(record!.id, filePath)
+    expect(updated).not.toBeNull()
+    expect(updated!.id).toBe(record!.id)
+    expect(updated!.token).not.toBe(record!.token)
+    const dbRecord = readImageRecord(updated!.id)
     expect(dbRecord!.token).toBe(updated!.token)
   })
 
-  it('should reject when updating a non-existent image', async () => {
+  it('should reject updates for non-existent images', async () => {
     const fakeId = `${testDir}:no-such-id`
     const filePath = path.join(assetsDir, '1-pixel.png')
-    await expect(updateImageFromFile(fakeId, filePath)).rejects.toThrow()
-  })
-})
-
-describe('getImageRecord', () => {
-  const testDir = 'getImageRecord'
-
-  it('should return the DB record for an existing image', async () => {
-    const filePath = path.join(assetsDir, '1-pixel.png')
-    const saved = await saveImageFromFile(filePath, testDir)
-
-    const result = getImageRecord(saved!.id)!
-    expect(result.id).toBe(saved!.id)
-    expect(result.token).toBe(saved!.token)
-  })
-
-  it('should return null if no record found', () => {
-    expect(getImageRecord(`${testDir}:nonexistent`)).toBeNull()
-  })
-})
-
-describe('getWirePayload', () => {
-  const testDir = 'getWirePayload'
-
-  it('should return encrypted, token, and meta for an existing image', async () => {
-    const filePath = path.join(assetsDir, '1-pixel.png')
-    const saved = await saveImageFromFile(filePath, testDir)
-
-    const { encrypted, token, meta } = await getWirePayload(saved!.id)
-
-    expect(Buffer.isBuffer(encrypted)).toBe(true)
-    expect(encrypted.length).toBeGreaterThan(0)
-    expect(token).toBe(saved!.token)
-
-    expect(meta).toBeDefined()
-  })
-
-  it('should throw if record is missing', async () => {
-    await expect(getWirePayload(`${testDir}:missing-id`)).rejects.toThrow(
-      'Image record not found',
+    await expect(updateImageFromFile(fakeId, filePath)).rejects.toThrow(
+      PixstoreError,
     )
   })
-})
 
-describe('deleteImage', () => {
-  const testDir = 'deleteImage'
-
-  it('should delete both file and DB record when both exist', async () => {
+  it('should get image record and statelessProof for existing image', async () => {
     const filePath = path.join(assetsDir, '1-pixel.png')
-    const saved = await saveImageFromFile(filePath, testDir)
-
-    expect(await deleteImage(saved!.id)).toBe(true)
-    expect(fs.existsSync(toFilePath(saved!.id))).toBe(false)
-    expect(readImageRecord(saved!.id)).toBeNull()
+    const record = await saveImageFromFile(filePath, testDir)
+    const result = getImageRecord(record!.id)
+    expect(result).not.toBeNull()
+    expect(result!.id).toBe(record!.id)
+    expect(result!.token).toBe(record!.token)
+    expect(result!.statelessProof).toBeDefined()
   })
 
-  it('should delete only DB record if file is already missing', async () => {
-    const filePath = path.join(assetsDir, '1-pixel.png')
-    const saved = await saveImageFromFile(filePath, testDir)
-
-    fs.unlinkSync(toFilePath(saved!.id))
-    expect(await deleteImage(saved!.id)).toBe(true)
-    expect(readImageRecord(saved!.id)).toBeNull()
+  it('should return null from getImageRecord for non-existent id', () => {
+    expect(getImageRecord(`${testDir}:does-not-exist`)).toBeNull()
   })
 
-  it('should return false if nothing existed', async () => {
+  it('should produce a valid wire payload for existing image', async () => {
+    const filePath = path.join(assetsDir, '1-pixel.png')
+    const record = await saveImageFromFile(filePath, testDir)
+    const payload = await getWirePayload(record!.id, undefined)
+
+    // Check for expected states
+    const allowedStates = [
+      WirePayloadState.Success,
+      WirePayloadState.Updated,
+      WirePayloadState.NotFound,
+    ]
+    expect(allowedStates).toContain(payload.state)
+
+    if (payload.state === WirePayloadState.Success) {
+      expect(payload.encrypted).toBeDefined()
+      expect('meta' in payload).toBe(false)
+      expect('token' in payload).toBe(false)
+    } else if (payload.state === WirePayloadState.Updated) {
+      expect(payload.encrypted).toBeDefined()
+      expect(payload.meta).toBeDefined()
+      expect(payload.token).toBeDefined()
+    } else if (payload.state === WirePayloadState.NotFound) {
+      expect(Object.keys(payload)).toEqual(['state'])
+    } else {
+      // For any error state, just check that only state exists
+      expect(Object.keys(payload)).toEqual(['state'])
+    }
+  })
+
+  it('should throw error from getWirePayload for truly missing image', async () => {
+    await expect(
+      getWirePayload(`${testDir}:ghost`, undefined),
+    ).resolves.toEqual({ state: 2 }) // NotFound
+  })
+
+  it('should delete file and DB record', async () => {
+    const filePath = path.join(assetsDir, '1-pixel.png')
+    const record = await saveImageFromFile(filePath, testDir)
+    expect(await deleteImage(record!.id)).toBe(true)
+    expect(fs.existsSync(toFilePath(record!.id))).toBe(false)
+    expect(readImageRecord(record!.id)).toBeNull()
+  })
+
+  it('should delete only DB record if file already gone', async () => {
+    const filePath = path.join(assetsDir, '1-pixel.png')
+    const record = await saveImageFromFile(filePath, testDir)
+    fs.unlinkSync(toFilePath(record!.id))
+    expect(await deleteImage(record!.id)).toBe(true)
+    expect(readImageRecord(record!.id)).toBeNull()
+  })
+
+  it('should return false if nothing to delete', async () => {
     expect(await deleteImage(`${testDir}:ghost`)).toBe(false)
   })
-})
 
-describe('imageExists', () => {
-  const testDir = 'imageExists'
-
-  it('should return true if both file and DB record exist', async () => {
+  it('should detect file and/or DB record existence', async () => {
     const filePath = path.join(assetsDir, '1-pixel.png')
-    const saved = await saveImageFromFile(filePath, testDir)
-    expect(await imageExists(saved!.id)).toBe(true)
-  })
-
-  it('should return true if only DB record exists', async () => {
-    const filePath = path.join(assetsDir, '1-pixel.png')
-    const saved = await saveImageFromFile(filePath, testDir)
-    fs.unlinkSync(toFilePath(saved!.id))
-    expect(await imageExists(saved!.id)).toBe(true)
-  })
-
-  it('should return false if neither exists', async () => {
-    expect(await imageExists(`${testDir}:nonexistent`)).toBe(false)
+    const record = await saveImageFromFile(filePath, testDir)
+    expect(await imageExists(record!.id)).toBe(true)
+    fs.unlinkSync(toFilePath(record!.id))
+    expect(await imageExists(record!.id)).toBe(true)
+    expect(await imageExists(`${testDir}:ghost`)).toBe(false)
   })
 })

--- a/tests/modules/backend/stateless-proof.test.ts
+++ b/tests/modules/backend/stateless-proof.test.ts
@@ -3,13 +3,10 @@ import {
   startDefaultEndpoint,
   stopDefaultEndpoint,
 } from '../../../src/backend/default-endpoint.js'
-import {
-  saveImage,
-  getImageRecord,
-} from '../../../src/backend/image-service.js'
+import { saveImage } from '../../../src/backend/image-service.js'
 import fs from 'fs/promises'
 import path from 'path'
-import { sleep } from '../../utils'
+import { sleep } from '../../utils/index.js'
 import { initializeDatabase } from '../../../src/backend/database.js'
 import { getCurrentStatelessProof } from '../../../src/backend/stateless-proof.js'
 
@@ -21,14 +18,14 @@ describe('customEndpointHelper', () => {
 
   beforeAll(async () => {
     initializeDatabase()
-    // Save a test image to backend and keep the ID
     const saved = await saveImage(await fs.readFile(ANTALYA_PATH), 'students')
     id = saved!.id
-    const imageRecord = getImageRecord(id)
   })
 
   it('returns valid wire format payload when default endpoint is not running', async () => {
     const proof = getCurrentStatelessProof(id)
+    // Yeni signature: customEndpointHelper(imageId: string, clientToken: number | null, statelessProof: string)
+    // clientToken burada undefined ya da null olabilir.
     const payload = await customEndpointHelper(id, undefined, proof)
     expect(payload).toBeInstanceOf(Uint8Array)
     expect(payload!.length).toBeGreaterThan(8)

--- a/tests/modules/frontend/custom-image-fetcher.test.ts
+++ b/tests/modules/frontend/custom-image-fetcher.test.ts
@@ -1,17 +1,18 @@
+import type { CustomImageFetcher } from '../../../src/types/image-fetcher.js'
 import {
   registerCustomImageFetcher,
   getCustomImageFetcher,
-} from '../../../src/frontend/custom-image-fetcher'
+} from '../../../src/frontend/custom-image-fetcher.js'
 
 describe('custom-image-fetcher', () => {
   it('registers and retrieves a custom fetcher', () => {
-    const fetcher = async (_: string) => new Uint8Array([1])
+    const fetcher: CustomImageFetcher = async (_) => new Uint8Array([1])
     registerCustomImageFetcher(fetcher)
     expect(getCustomImageFetcher()).toBe(fetcher)
   })
 
   it('returns undefined if no custom fetcher is registered', () => {
-    registerCustomImageFetcher(undefined as any)
+    registerCustomImageFetcher(undefined)
     expect(getCustomImageFetcher()).toBeUndefined()
   })
 })

--- a/tests/modules/frontend/image-fetcher.test.ts
+++ b/tests/modules/frontend/image-fetcher.test.ts
@@ -3,26 +3,38 @@ import { registerCustomImageFetcher } from '../../../src/frontend/custom-image-f
 import * as defaultFetcherModule from '../../../src/frontend/default-image-fetcher'
 
 describe('fetchEncodedImage', () => {
-  const testId = 'abc123'
+  const parameters = {
+    imageId: 'abc123',
+    imageToken: 123,
+    statelessProof: 'test-proof',
+    context: undefined,
+  }
   const defaultData = new Uint8Array([42])
   const customData = new Uint8Array([99])
+
+  afterEach(() => {
+    // Always unregister custom fetcher after each test to avoid cross-test pollution
+    registerCustomImageFetcher(undefined)
+    jest.restoreAllMocks()
+  })
+
   it('uses default fetcher if no custom fetcher is registered', async () => {
     jest
       .spyOn(defaultFetcherModule, 'getDefaultImageFetcher')
-      .mockReturnValue(async (id: string) => {
-        expect(id).toBe(testId)
+      .mockReturnValue(async (params) => {
+        expect(params).toEqual(parameters)
         return defaultData
       })
-    const result = await fetchEncodedImage(testId)
+    const result = await fetchEncodedImage(parameters)
     expect(result).toEqual(defaultData)
   })
 
   it('uses custom fetcher if registered', async () => {
-    registerCustomImageFetcher(async (id) => {
-      expect(id).toBe(testId)
+    registerCustomImageFetcher(async (params) => {
+      expect(params).toEqual(parameters)
       return customData
     })
-    const result = await fetchEncodedImage(testId)
+    const result = await fetchEncodedImage(parameters)
     expect(result).toEqual(customData)
   })
 })

--- a/tests/modules/frontend/image-service.test.ts
+++ b/tests/modules/frontend/image-service.test.ts
@@ -1,5 +1,4 @@
 import '../../utils/frontend-crypto-polyfill.js'
-
 import 'fake-indexeddb/auto'
 import path from 'path'
 import fs from 'fs/promises'
@@ -16,12 +15,13 @@ import {
 } from '../../../src/backend/default-endpoint.js'
 import { saveImage, updateImage } from '../../../src/backend/image-service.js'
 import { initializeDatabase } from '../../../src/backend/database.js'
+import { getCurrentStatelessProof } from '../../../src/backend/stateless-proof.js'
 
 const assetDir = path.resolve(__dirname, '../../assets')
 const ANTALYA_PATH = path.join(assetDir, 'antalya.jpg')
 const VILNIUS_PATH = path.join(assetDir, 'vilnius.jpg')
 
-// helper: compare two Blobs byte-for-byte
+// Helper: compare two Blobs byte-for-byte
 const expectBlobsToBeEqual = async (a: Blob, b: Blob) => {
   const bufA = Buffer.from(await a.arrayBuffer())
   const bufB = Buffer.from(await b.arrayBuffer())
@@ -32,7 +32,7 @@ beforeAll(() => {
   initializeDatabase()
 })
 
-describe('frontend image-service – full flow', () => {
+describe('Pixstore frontend image-service – full flow', () => {
   let record: ImageRecord
 
   beforeAll(async () => {
@@ -46,6 +46,7 @@ describe('frontend image-service – full flow', () => {
         iv: saved!.meta.iv,
         tag: saved!.meta.tag,
       },
+      statelessProof: getCurrentStatelessProof(saved!.id),
     }
   })
 
@@ -55,15 +56,16 @@ describe('frontend image-service – full flow', () => {
 
   it('caches, deletes, and refreshes image correctly with blob and token validation', async () => {
     // 1) Initial fetch: retrieve from backend and store in cache
+    record.statelessProof = getCurrentStatelessProof(record.id)
     const blob1 = await getImage(record)
     expect(blob1).toBeInstanceOf(Blob)
 
     // 2) Compare blob content with original backend file
     const _originalBuffer = await fs.readFile(ANTALYA_PATH)
-    const originalBuffer = new Blob([new Uint8Array(_originalBuffer)], {
+    const originalBlob = new Blob([new Uint8Array(_originalBuffer)], {
       type: blob1!.type,
     })
-    await expectBlobsToBeEqual(blob1!, originalBuffer)
+    await expectBlobsToBeEqual(blob1!, originalBlob)
 
     // 3) Ensure cached record token matches backend token
     const cachedRecord1 = await readImageRecord(record.id)
@@ -80,19 +82,18 @@ describe('frontend image-service – full flow', () => {
     expect(exists2).toBe(false)
 
     // 6) Re-fetch after deletion: should re-cache original blob
+    record.statelessProof = getCurrentStatelessProof(record.id)
     const blob2 = await getImage(record)
     expect(blob2).toBeInstanceOf(Blob)
     await expectBlobsToBeEqual(blob2!, blob1!)
 
-    // 7) Update backend image (same ID, new token)
+    // 7) Update backend image (same ID, new token/meta)
     const updated = await updateImage(
       record.id,
       await fs.readFile(VILNIUS_PATH),
     )
     expect(updated!.token).not.toBe(record.token)
-
-    // 8) Token mismatch triggers cache update on getImage
-    const blob3 = await getImage({
+    const updatedRecord: ImageRecord = {
       id: updated!.id,
       token: updated!.token,
       meta: {
@@ -100,7 +101,12 @@ describe('frontend image-service – full flow', () => {
         iv: updated!.meta.iv,
         tag: updated!.meta.tag,
       },
-    })
+      statelessProof: getCurrentStatelessProof(updated!.id),
+    }
+
+    // 8) Token mismatch triggers cache update on getImage
+    updatedRecord.statelessProof = getCurrentStatelessProof(updatedRecord.id)
+    const blob3 = await getImage(updatedRecord)
     expect(blob3).toBeInstanceOf(Blob)
     const buf2 = Buffer.from(await blob2!.arrayBuffer())
     const buf3 = Buffer.from(await blob3!.arrayBuffer())

--- a/tests/modules/shared/pixstore-config.test.ts
+++ b/tests/modules/shared/pixstore-config.test.ts
@@ -74,4 +74,27 @@ describe('Pixstore config system', () => {
       'defaultEndpointConnectPort must be an integer between 1 and 65535',
     )
   })
+  it('throws if statelessKeyWindowLength is 0, negative, or non-numeric', () => {
+    expect(() => initPixstore({ statelessKeyWindowLength: 0 })).toThrow(
+      'statelessKeyWindowLength must be a positive integer (milliseconds) or -1 for non-expiring proof',
+    )
+    expect(() => initPixstore({ statelessKeyWindowLength: -5 })).toThrow(
+      'statelessKeyWindowLength must be a positive integer (milliseconds) or -1 for non-expiring proof',
+    )
+    expect(() => initPixstore({ statelessKeyWindowLength: NaN })).toThrow(
+      'statelessKeyWindowLength must be a positive integer (milliseconds) or -1 for non-expiring proof',
+    )
+    expect(() =>
+      initPixstore({ statelessKeyWindowLength: 'abc' as any }),
+    ).toThrow(
+      'statelessKeyWindowLength must be a positive integer (milliseconds) or -1 for non-expiring proof',
+    )
+  })
+
+  it('allows statelessKeyWindowLength = -1 (non-expiring) or positive integer', () => {
+    expect(() => initPixstore({ statelessKeyWindowLength: -1 })).not.toThrow()
+    expect(() =>
+      initPixstore({ statelessKeyWindowLength: 60000 }),
+    ).not.toThrow()
+  })
 })

--- a/tests/modules/shared/wire-encoder.test.ts
+++ b/tests/modules/shared/wire-encoder.test.ts
@@ -7,10 +7,14 @@ import {
   AES_IV_SIZE,
   AES_GCM_TAG_LENGTH,
 } from '../../../src/shared/constants.js'
-import { BackendWirePayload } from '../../../src/types/wire-payload.js'
+import {
+  WirePayloadState,
+  type BackendWirePayload,
+} from '../../../src/types/wire-payload.js'
 import { arrayBufferToBase64 } from '../../../src/shared/format-buffer.js'
-import { ImageDecryptionMeta } from '../../../src/types/image-decryption-meta.js'
+import type { ImageDecryptionMeta } from '../../../src/types/image-decryption-meta.js'
 
+// Generates random buffer of given size
 const randomBuf = (size: number) => {
   return Buffer.from(
     Array.from({ length: size }, () => Math.floor(Math.random() * 256)),
@@ -18,40 +22,73 @@ const randomBuf = (size: number) => {
 }
 
 describe('Wire Encoder', () => {
-  it('encodeWirePayload + decodeWirePayload should be lossless & compatible', () => {
-    // Random test data
+  it('should correctly encode and decode a Success payload', () => {
+    const encrypted = randomBuf(16)
+    const payload: BackendWirePayload = {
+      state: WirePayloadState.Success,
+      encrypted,
+    }
+
+    const encoded = encodeWirePayload(payload)
+
+    const decoded = decodeWirePayload(encoded)
+
+    expect(decoded.state).toBe(WirePayloadState.Success)
+    if (decoded.state === WirePayloadState.Success) {
+      expect(new Uint8Array(decoded.encrypted)).toEqual(
+        new Uint8Array(encrypted),
+      )
+      expect('token' in decoded).toBe(false)
+      expect('meta' in decoded).toBe(false)
+    } else {
+      throw new Error('Expected Success state payload')
+    }
+  })
+
+  it('should correctly encode and decode an Updated payload', () => {
     const token = 42
     const key = arrayBufferToBase64(randomBuf(AES_KEY_SIZE))
     const iv = arrayBufferToBase64(randomBuf(AES_IV_SIZE))
     const tag = arrayBufferToBase64(randomBuf(AES_GCM_TAG_LENGTH / 8))
-    const encrypted = randomBuf(9)
+    const encrypted = randomBuf(16)
 
-    const meta: ImageDecryptionMeta = {
-      key,
-      iv,
-      tag,
-    }
-
-    // BackendWirePayload format (encode input)
+    const meta: ImageDecryptionMeta = { key, iv, tag }
     const payload: BackendWirePayload = {
+      state: WirePayloadState.Updated,
       token,
       meta,
       encrypted,
     }
 
-    // Encode & decode
     const encoded = encodeWirePayload(payload)
     const decoded = decodeWirePayload(encoded)
 
-    // Token
-    expect(decoded.token).toBe(token)
-
-    // Meta: ArrayBuffer equality (byte-for-byte)
-    expect(decoded.meta.key).toEqual(key)
-    expect(decoded.meta.iv).toEqual(iv)
-    expect(decoded.meta.tag).toEqual(tag)
-
-    // Encrypted: Uint8Array equality
-    expect(new Uint8Array(decoded.encrypted)).toEqual(new Uint8Array(encrypted))
+    expect(decoded.state).toBe(WirePayloadState.Updated)
+    // Only in Updated state, these fields must exist:
+    if (decoded.state === WirePayloadState.Updated) {
+      expect(decoded.token).toBe(token)
+      expect(decoded.meta.key).toBe(key)
+      expect(decoded.meta.iv).toBe(iv)
+      expect(decoded.meta.tag).toBe(tag)
+      expect(new Uint8Array(decoded.encrypted)).toEqual(
+        new Uint8Array(encrypted),
+      )
+    } else {
+      throw new Error('Decoded payload is not in Updated state')
+    }
   })
+
+  const errorStates: BackendWirePayload[] = [
+    { state: WirePayloadState.NotFound },
+    { state: WirePayloadState.InvalidProof },
+    { state: WirePayloadState.MissingID },
+    { state: WirePayloadState.MissingProof },
+    { state: WirePayloadState.InternalError },
+  ]
+  for (const payload of errorStates) {
+    const encoded = encodeWirePayload(payload)
+    const decoded = decodeWirePayload(encoded)
+    expect(decoded.state).toBe(payload.state)
+    expect(Object.keys(decoded)).toEqual(['state'])
+  }
 })

--- a/tests/scenario/backend-image-highload.test.ts
+++ b/tests/scenario/backend-image-highload.test.ts
@@ -31,11 +31,20 @@ describe('Pixstore backend highload scenario', () => {
       ids.push(record!.id)
     }
   })
-
   it('should read all images', async () => {
     for (const id of ids) {
-      const { encrypted } = await getWirePayload(id)
-      expect(encrypted.length).toBeGreaterThan(0)
+      const payload = await getWirePayload(id, undefined)
+      // Only assert encrypted if image is found and state is Success/Updated
+      if (
+        payload.state === 0 || // WirePayloadState.Success
+        payload.state === 1 // WirePayloadState.Updated
+      ) {
+        expect(payload.encrypted.length).toBeGreaterThan(0)
+      } else {
+        throw new Error(
+          `Image not found or wrong state for id: ${id}, state=${payload.state}`,
+        )
+      }
     }
   })
 
@@ -43,15 +52,33 @@ describe('Pixstore backend highload scenario', () => {
     const buffer2 = fs.readFileSync(imageFile2)
     for (const id of ids) {
       await updateImage(id, buffer2)
-      const { encrypted } = await getWirePayload(id)
-      expect(encrypted.length).toBeGreaterThan(0)
+      const payload = await getWirePayload(id, undefined)
+      if (
+        payload.state === 0 || // WirePayloadState.Success
+        payload.state === 1 // WirePayloadState.Updated
+      ) {
+        expect(payload.encrypted.length).toBeGreaterThan(0)
+      } else {
+        throw new Error(
+          `Image not found or wrong state for id: ${id}, state=${payload.state}`,
+        )
+      }
     }
   })
 
   it('should read all images after update', async () => {
     for (const id of ids) {
-      const { encrypted } = await getWirePayload(id)
-      expect(encrypted.length).toBeGreaterThan(0)
+      const payload = await getWirePayload(id, undefined)
+      if (
+        payload.state === 0 || // WirePayloadState.Success
+        payload.state === 1 // WirePayloadState.Updated
+      ) {
+        expect(payload.encrypted.length).toBeGreaterThan(0)
+      } else {
+        throw new Error(
+          `Image not found or wrong state for id: ${id}, state=${payload.state}`,
+        )
+      }
     }
   })
 


### PR DESCRIPTION
- Implements stateless proof-of-access for the default image endpoint. The default endpoint is no longer public; secure token and proof are now required for image access.
- Overhauls the wire protocol: status byte-based, minimal responses, no more exposing encryption keys/IVs to the frontend unless strictly required.
- BREAKING: Refactors ImageRecord, fetchers, and API types. All image access and fetch flows now require statelessProof and updated ImageRecord shape (token, meta, statelessProof).
- Enforces protocol-agnostic error handling: all requests return HTTP 200 with a leading state byte (errors are handled client-side).
- Adds validation for all stateless proof and endpoint parameters. Supports both time-based and time-invariant proofs (for local/demo use).
- Updates Pixstore API types (ImageRecord, ImageFetcher, etc.) to support new stateless model.
- Refactors all tests and example application code (NestJS+Vue, Express+React) to use the new protocol and secure flow.
- Example 2 now imports Pixstore from the local build (`dist/`) instead of npm.
- Adds config validation for statelessKeyWindowLength, supports time-invariant mode via -1, improved comments.

BREAKING CHANGE:
- ImageRecord and all related access flows now require `statelessProof` and updated parameter structure; previous usages are incompatible.
- Default endpoint is now secure and requires proof/token; public image fetching is no longer supported.
- Wire protocol and API contracts are incompatible with previous Pixstore versions.
- All client and backend integrations (including examples) must be updated to use the new access flow.

Closes #62