### PR TITLE
Fix cache timestamp + refactor endpoint helper signature

### DIFF
--- a/examples/example-2-express-react-custom-endpoint/backend/src/controllers/player-image.ts
+++ b/examples/example-2-express-react-custom-endpoint/backend/src/controllers/player-image.ts
@@ -49,7 +49,7 @@ export const getPlayerImage = async (
   try {
     const clientTokenRaw = req.query.token ?? req.headers['x-pixstore-token']
     const clientToken =
-      clientTokenRaw !== undefined ? Number(clientTokenRaw) : undefined
+      clientTokenRaw !== undefined ? Number(clientTokenRaw) : 0
 
     const statelessProofRaw = req.query.proof ?? req.headers['x-pixstore-proof']
     const statelessProof =

--- a/examples/example-2-express-react-custom-endpoint/frontend/src/init-pixstore.ts
+++ b/examples/example-2-express-react-custom-endpoint/frontend/src/init-pixstore.ts
@@ -4,7 +4,7 @@
 //   import { initPixstoreBackend } from 'pixstore/backend'
 //
 import { initPixstoreFrontend } from '../../../../dist/frontend'
-import type { ImageFetcher } from '../../../../dist/types'
+import type { ImageFetcher, ImageRecord } from '../../../../dist/types'
 import { useAuth } from './store/auth'
 import { API_BASE } from './constants'
 
@@ -20,18 +20,17 @@ const FRONTEND_CLEANUP_BATCH = 2 // Number of images to clean up in a single bat
  * The custom fetcher allows sending the playerId and JWT to the backend for secure image access.
  * This is REQUIRED to support custom image endpoint and role-based access.
  */
-const customImageFetcher: ImageFetcher = async ({
-  imageId,
-  imageToken,
-  statelessProof,
-  context,
-}) => {
-  const { playerId } = context
+const customImageFetcher: ImageFetcher = async (
+  imageRecord: ImageRecord,
+  { playerId },
+) => {
+  console.log('test!!')
+  const { id: imageId, token: imageToken, statelessProof } = imageRecord
+
   const jwt = useAuth.getState().jwt
 
   const headers: Record<string, string> = {
     Authorization: `Bearer ${jwt}`,
-    // Pixstore endpointleri için zorunlu
     'x-pixstore-proof': statelessProof,
   }
   if (imageToken !== undefined) {

--- a/src/backend/custom-endpoint.ts
+++ b/src/backend/custom-endpoint.ts
@@ -15,7 +15,7 @@ import { WirePayloadState } from '../types/wire-payload.js'
  */
 export const customEndpointHelper = async (
   imageId: string,
-  clientToken: number | undefined,
+  clientToken: number,
   statelessProof: string,
 ): Promise<Uint8Array | null> => {
   return handleErrorAsync(async () => {

--- a/src/frontend/custom-image-fetcher.ts
+++ b/src/frontend/custom-image-fetcher.ts
@@ -1,16 +1,16 @@
-import type { CustomImageFetcher } from '../types/image-fetcher.js'
+import type { ImageFetcher } from '../types/image-fetcher.js'
 
 /**
  * Stores the current custom fetcher function if registered by the user.
  */
-let customImageFetcher: CustomImageFetcher | undefined
+let customImageFetcher: ImageFetcher | undefined
 
 /**
  * Registers a custom fetcher function for image retrieval.
  * When set, this function will be used instead of the default fetcher.
  */
 export const registerCustomImageFetcher = (
-  fetcher: CustomImageFetcher | undefined,
+  fetcher: ImageFetcher | undefined,
 ) => {
   if (customImageFetcher && fetcher) {
     console.warn('Overwriting existing custom image fetcher.')

--- a/src/frontend/default-image-fetcher.ts
+++ b/src/frontend/default-image-fetcher.ts
@@ -9,14 +9,9 @@ import type { ImageFetcher } from '../types/image-fetcher.js'
  * the current wire protocol (status byte, token, stateless proof in headers).
  */
 const defaultImageFetcher: ImageFetcher = async (
-  parameters,
+  imageRecord,
 ): Promise<Uint8Array> => {
-  const {
-    imageId,
-    imageToken,
-    statelessProof,
-    // context (optional, ignored here)
-  } = parameters
+  const { id: imageId, token: imageToken, statelessProof } = imageRecord
 
   const DEFAULT_ENDPOINT_PORT = pixstoreConfig.defaultEndpointConnectPort
   const DEFAULT_ENDPOINT_ROUTE = pixstoreConfig.defaultEndpointRoute

--- a/src/frontend/image-fetcher.ts
+++ b/src/frontend/image-fetcher.ts
@@ -7,12 +7,12 @@ import { getDefaultImageFetcher } from './default-image-fetcher.js'
  * (if registered) or the default Pixstore fetcher.
  * Always returns the wire-format Uint8Array for the given image id.
  */
-export const fetchEncodedImage: ImageFetcher = async (parameters) => {
+export const fetchEncodedImage: ImageFetcher = async (...parameters) => {
   const customImageFetcher = getCustomImageFetcher()
 
   if (customImageFetcher) {
-    return customImageFetcher(parameters)
+    return customImageFetcher(...parameters)
   }
   const defaultImageFetcher = getDefaultImageFetcher()
-  return defaultImageFetcher(parameters)
+  return defaultImageFetcher(...parameters)
 }

--- a/src/frontend/image-service.ts
+++ b/src/frontend/image-service.ts
@@ -45,17 +45,8 @@ export const getImage = async (
       return decryptedPayloadToBlob(imagePayload)
     }
 
-    // If the cached token is outdated (record was updated elsewhere), use the cached token for conditional request.
-    const clientToken =
-      cached && cached.token !== token ? cached.token : undefined
-
     // Otherwise, fetch the latest encoded image from the backend
-    const encoded = await fetchEncodedImage({
-      imageId: id,
-      imageToken: clientToken,
-      statelessProof,
-      context,
-    })
+    const encoded = await fetchEncodedImage(record, context)
 
     // Decode the wire payload to extract encrypted data, meta, and token
     const decodedWirePayload = decodeWirePayload(encoded)

--- a/src/frontend/image-service.ts
+++ b/src/frontend/image-service.ts
@@ -35,6 +35,12 @@ export const getImage = async (
       // Decrypt the image using the extracted encrypted data and meta
       const imagePayload = await decryptImage(encrypted, meta)
 
+      // Update lastUsed timestamp (wihtout awaiting)
+      writeImageRecord({
+        ...indexedDBRecord!,
+        lastUsed: Date.now(),
+      })
+
       // Return the up-to-date Blob for rendering
       return decryptedPayloadToBlob(imagePayload)
     }
@@ -79,8 +85,8 @@ export const getImage = async (
       lastUsed: Date.now(),
     }
 
-    // Save the updated image into the local cache
-    await writeImageRecord(indexedDBRecord)
+    // Save the updated image into the local cache (wihtout awaiting)
+    writeImageRecord(indexedDBRecord)
 
     // Use the correct meta depending on response state (Success keeps old meta, Updated uses new meta)
     const latestMeta =

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -1,7 +1,7 @@
 import type { PixstoreFrontendConfig } from '../types/pixstore-config.js'
 import { initPixstore } from '../shared/pixstore-config.js'
 import { registerCustomImageFetcher } from './custom-image-fetcher.js'
-import type { CustomImageFetcher } from '../types/image-fetcher.js'
+import type { ImageFetcher } from '../types/image-fetcher.js'
 
 /**
  * Initializes the Pixstore frontend module with the given configuration.
@@ -9,7 +9,7 @@ import type { CustomImageFetcher } from '../types/image-fetcher.js'
  */
 export const initPixstoreFrontend = (
   config: Partial<PixstoreFrontendConfig> = {},
-  customImageFetcher?: CustomImageFetcher,
+  customImageFetcher?: ImageFetcher,
 ) => {
   // Apply user config to internal state
   initPixstore(config)

--- a/src/types/image-fetcher.ts
+++ b/src/types/image-fetcher.ts
@@ -1,8 +1,6 @@
-export type ImageFetcher = (parameters: {
-  imageId: string
-  imageToken: number | undefined
-  statelessProof: string
-  context?: any
-}) => Promise<Uint8Array>
+import { ImageRecord } from './image-record.ts'
 
-export type CustomImageFetcher = ImageFetcher
+export type ImageFetcher = (
+  imageRecord: ImageRecord,
+  context?: any,
+) => Promise<Uint8Array>

--- a/tests/modules/backend/custom-endpoint.test.ts
+++ b/tests/modules/backend/custom-endpoint.test.ts
@@ -29,7 +29,7 @@ describe('customEndpointHelper', () => {
 
   it('returns valid wire format payload when default endpoint is not running', async () => {
     const proof = getCurrentStatelessProof(id)
-    const payload = await customEndpointHelper(id, undefined, proof)
+    const payload = await customEndpointHelper(id, 0, proof)
     expect(payload).toBeInstanceOf(Uint8Array)
     expect(payload!.length).toBeGreaterThan(8)
   })
@@ -38,7 +38,7 @@ describe('customEndpointHelper', () => {
     startDefaultEndpoint()
     await sleep(50)
     const proof = getCurrentStatelessProof(id)
-    await expect(customEndpointHelper(id, undefined, proof)).rejects.toThrow(
+    await expect(customEndpointHelper(id, 0, proof)).rejects.toThrow(
       /custom endpoint mode is not active|default endpoint/i,
     )
     await stopDefaultEndpoint()

--- a/tests/modules/backend/stateless-proof.test.ts
+++ b/tests/modules/backend/stateless-proof.test.ts
@@ -26,7 +26,7 @@ describe('customEndpointHelper', () => {
     const proof = getCurrentStatelessProof(id)
     // Yeni signature: customEndpointHelper(imageId: string, clientToken: number | null, statelessProof: string)
     // clientToken burada undefined ya da null olabilir.
-    const payload = await customEndpointHelper(id, undefined, proof)
+    const payload = await customEndpointHelper(id, 0, proof)
     expect(payload).toBeInstanceOf(Uint8Array)
     expect(payload!.length).toBeGreaterThan(8)
   })
@@ -35,7 +35,7 @@ describe('customEndpointHelper', () => {
     startDefaultEndpoint()
     await sleep(50)
     const proof = getCurrentStatelessProof(id)
-    await expect(customEndpointHelper(id, undefined, proof)).rejects.toThrow(
+    await expect(customEndpointHelper(id, 0, proof)).rejects.toThrow(
       /custom endpoint mode is not active|default endpoint/i,
     )
     await stopDefaultEndpoint()

--- a/tests/modules/frontend/custom-image-fetcher.test.ts
+++ b/tests/modules/frontend/custom-image-fetcher.test.ts
@@ -1,4 +1,4 @@
-import type { CustomImageFetcher } from '../../../src/types/image-fetcher.js'
+import type { ImageFetcher } from '../../../src/types/image-fetcher.js'
 import {
   registerCustomImageFetcher,
   getCustomImageFetcher,
@@ -6,7 +6,7 @@ import {
 
 describe('custom-image-fetcher', () => {
   it('registers and retrieves a custom fetcher', () => {
-    const fetcher: CustomImageFetcher = async (_) => new Uint8Array([1])
+    const fetcher: ImageFetcher = async (_) => new Uint8Array([1])
     registerCustomImageFetcher(fetcher)
     expect(getCustomImageFetcher()).toBe(fetcher)
   })

--- a/tests/modules/frontend/default-image-fetcher.test.ts
+++ b/tests/modules/frontend/default-image-fetcher.test.ts
@@ -33,11 +33,7 @@ describe('fetchEncodedImage (integration)', () => {
   })
   it('fetches and decodes the image as expected', async () => {
     const statelessProof = getCurrentStatelessProof(record!.id)
-    const encoded = await fetchEncodedImage({
-      imageId: record!.id,
-      imageToken: record!.token,
-      statelessProof,
-    })
+    const encoded = await fetchEncodedImage(record!)
     const decoded = decodeWirePayload(encoded)
 
     expect([WirePayloadState.Success, WirePayloadState.Updated]).toContain(
@@ -83,9 +79,14 @@ describe('fetchEncodedImage (integration)', () => {
     const fakeId = 'fetcher:notfound'
     const proof = getCurrentStatelessProof(fakeId)
     const encoded = await fetchEncodedImage({
-      imageId: fakeId,
-      imageToken: undefined,
+      id: fakeId,
+      token: 0,
       statelessProof: proof,
+      meta: {
+        key: 'test-key',
+        iv: 'test-iv',
+        tag: 'test-tag',
+      },
     })
     const decoded = decodeWirePayload(encoded)
     expect([

--- a/tests/modules/frontend/image-fetcher.test.ts
+++ b/tests/modules/frontend/image-fetcher.test.ts
@@ -3,17 +3,20 @@ import { registerCustomImageFetcher } from '../../../src/frontend/custom-image-f
 import * as defaultFetcherModule from '../../../src/frontend/default-image-fetcher'
 
 describe('fetchEncodedImage', () => {
-  const parameters = {
-    imageId: 'abc123',
-    imageToken: 123,
+  const imageRecord = {
+    id: 'abc123',
+    token: 123,
     statelessProof: 'test-proof',
-    context: undefined,
+    meta: {
+      key: 'test-key',
+      iv: 'test-iv',
+      tag: 'test-tag',
+    },
   }
   const defaultData = new Uint8Array([42])
   const customData = new Uint8Array([99])
 
   afterEach(() => {
-    // Always unregister custom fetcher after each test to avoid cross-test pollution
     registerCustomImageFetcher(undefined)
     jest.restoreAllMocks()
   })
@@ -22,19 +25,19 @@ describe('fetchEncodedImage', () => {
     jest
       .spyOn(defaultFetcherModule, 'getDefaultImageFetcher')
       .mockReturnValue(async (params) => {
-        expect(params).toEqual(parameters)
+        expect(params).toEqual(imageRecord)
         return defaultData
       })
-    const result = await fetchEncodedImage(parameters)
+    const result = await fetchEncodedImage(imageRecord)
     expect(result).toEqual(defaultData)
   })
 
   it('uses custom fetcher if registered', async () => {
     registerCustomImageFetcher(async (params) => {
-      expect(params).toEqual(parameters)
+      expect(params).toEqual(imageRecord)
       return customData
     })
-    const result = await fetchEncodedImage(parameters)
+    const result = await fetchEncodedImage(imageRecord)
     expect(result).toEqual(customData)
   })
 })


### PR DESCRIPTION
fix: update lastUsed timestamp when returning cached image

- Ensure lastUsed is updated on cache hit (when token matches)
- Use non-blocking writeImageRecord calls
- Added integration test to validate timestamp update

Closes #66

feat: improve fetcher API and enforce token in customEndpointHelper

- Require clientToken in customEndpointHelper for stricter validation
- Unify ImageFetcher signature with context parameter
- Remove redundant CustomImageFetcher type alias
- Update fetchEncodedImage to support context passthrough
- Adapt default and custom fetchers to new signature
- Update all related integration tests and usage examples

Closes #67